### PR TITLE
Proposed new arrangement for annotations.

### DIFF
--- a/oscm-rest-api-account/src/main/java/org/oscm/rest/account/BillingContactResource.java
+++ b/oscm-rest-api-account/src/main/java/org/oscm/rest/account/BillingContactResource.java
@@ -33,7 +33,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 @Path(CommonParams.PATH_VERSION + "/billingcontacts")
-@Produces(MediaType.APPLICATION_JSON)
 @Since(CommonParams.VERSION_1)
 @Stateless
 public class BillingContactResource extends RestResource {
@@ -128,8 +127,7 @@ public class BillingContactResource extends RestResource {
           responses = {
                   @ApiResponse(responseCode = "204", description = "Billing contact updated successfully")
           })
-  public Response updateBillingContact(
-      @Context UriInfo uriInfo,
+  public Response updateBillingContact(@Context UriInfo uriInfo,
       BillingContactRepresentation content,
       @BeanParam AccountParameters params)
       throws Exception {

--- a/oscm-rest-api-account/src/main/java/org/oscm/rest/account/BillingContactResource.java
+++ b/oscm-rest-api-account/src/main/java/org/oscm/rest/account/BillingContactResource.java
@@ -28,7 +28,6 @@ import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 

--- a/oscm-rest-api-account/src/main/java/org/oscm/rest/account/OrganizationResource.java
+++ b/oscm-rest-api-account/src/main/java/org/oscm/rest/account/OrganizationResource.java
@@ -27,15 +27,16 @@ import org.oscm.rest.common.Since;
 
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
-import javax.ws.rs.*;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/organizations")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class OrganizationResource extends RestResource {
 
@@ -53,14 +54,12 @@ public class OrganizationResource extends RestResource {
                           schema = @Schema(implementation = OrganizationRepresentation.class)
                   ))
           })
-  public Response getOrganization(@Context UriInfo uriInfo,
-                                  @BeanParam AccountParameters params)
+  public Response getOrganization(@Context UriInfo uriInfo, @BeanParam AccountParameters params)
           throws Exception {
     return get(uriInfo, ab.getOrganization(), params, true);
   }
 
   @POST
-  @Consumes(MediaType.APPLICATION_JSON)
   @Operation(summary = "Create an organization",
           tags = {"organization"},
           description = "Creates an organization",

--- a/oscm-rest-api-account/src/main/java/org/oscm/rest/account/OrganizationResource.java
+++ b/oscm-rest-api-account/src/main/java/org/oscm/rest/account/OrganizationResource.java
@@ -60,7 +60,6 @@ public class OrganizationResource extends RestResource {
   }
 
   @POST
-  @Consumes(MediaType.APPLICATION_JSON)
   @Operation(summary = "Create an organization",
           tags = {"organization"},
           description = "Creates an organization",

--- a/oscm-rest-api-account/src/main/java/org/oscm/rest/account/PaymentInfoResource.java
+++ b/oscm-rest-api-account/src/main/java/org/oscm/rest/account/PaymentInfoResource.java
@@ -28,13 +28,11 @@ import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/paymentinfos")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class PaymentInfoResource extends RestResource {
 
@@ -72,7 +70,6 @@ public class PaymentInfoResource extends RestResource {
   }
 
   @PUT
-  @Consumes(MediaType.APPLICATION_JSON)
   @Path(CommonParams.PATH_ID)
   @Operation(summary = "Update a single payment info",
           tags = {"paymentinfo"},

--- a/oscm-rest-api-account/src/main/java/org/oscm/rest/account/PaymentInfoResource.java
+++ b/oscm-rest-api-account/src/main/java/org/oscm/rest/account/PaymentInfoResource.java
@@ -70,7 +70,6 @@ public class PaymentInfoResource extends RestResource {
   }
 
   @PUT
-  @Consumes(MediaType.APPLICATION_JSON)
   @Path(CommonParams.PATH_ID)
   @Operation(summary = "Update a single payment info",
           tags = {"paymentinfo"},

--- a/oscm-rest-api-common/src/main/java/org/oscm/rest/common/RestResource.java
+++ b/oscm-rest-api-common/src/main/java/org/oscm/rest/common/RestResource.java
@@ -9,7 +9,10 @@
  */
 package org.oscm.rest.common;
 
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
@@ -36,6 +39,7 @@ public abstract class RestResource {
    * @param id true if id needs to be validated
    * @return the response with representation or -collection
    */
+  @Produces(MediaType.APPLICATION_JSON)
   protected <R extends Representation, P extends RequestParameters> Response get(
       UriInfo uriInfo, RestBackend.Get<R, P> backend, P params, boolean id) throws Exception {
 
@@ -65,6 +69,7 @@ public abstract class RestResource {
    * @return the response with representation collection
    * @throws Exception
    */
+  @Produces(MediaType.APPLICATION_JSON)
   protected <R extends Representation, P extends RequestParameters> Response getCollection(
       UriInfo uriInfo, RestBackend.GetCollection<R, P> backend, P params) throws Exception {
 
@@ -94,6 +99,8 @@ public abstract class RestResource {
    * @param params the request parameters
    * @return the response with the new location
    */
+  @Produces(MediaType.APPLICATION_JSON)
+  @Consumes(MediaType.APPLICATION_JSON)
   protected <R extends Representation, P extends RequestParameters> Response post(
       UriInfo uriInfo, RestBackend.Post<R, P> backend, R content, P params) throws Exception {
 
@@ -117,6 +124,8 @@ public abstract class RestResource {
    * @param params the request parameters
    * @return the response without content
    */
+  @Produces(MediaType.APPLICATION_JSON)
+  @Consumes(MediaType.APPLICATION_JSON)
   protected <R extends Representation, P extends RequestParameters> Response put(
       UriInfo uriInfo, RestBackend.Put<R, P> backend, R content, P params) throws Exception {
 
@@ -143,6 +152,7 @@ public abstract class RestResource {
    * @param params the request parameters
    * @return the response without content
    */
+  @Produces(MediaType.APPLICATION_JSON)
   protected <P extends RequestParameters> Response delete(
       UriInfo uriInfo, RestBackend.Delete<P> backend, P params) throws Exception {
 

--- a/oscm-rest-api-event/src/main/java/org/oscm/rest/event/EventResource.java
+++ b/oscm-rest-api-event/src/main/java/org/oscm/rest/event/EventResource.java
@@ -43,7 +43,6 @@ public class EventResource extends RestResource {
   EventBackend eb;
 
   @POST
-  @Consumes(MediaType.APPLICATION_JSON)
   @Operation(summary = "Create a single event.",
           tags = {"event"},
           description = "Creates a single event.",

--- a/oscm-rest-api-event/src/main/java/org/oscm/rest/event/EventResource.java
+++ b/oscm-rest-api-event/src/main/java/org/oscm/rest/event/EventResource.java
@@ -26,15 +26,15 @@ import org.oscm.rest.event.data.EventRepresentation;
 
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
-import javax.ws.rs.*;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/events")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class EventResource extends RestResource {
 
@@ -43,7 +43,6 @@ public class EventResource extends RestResource {
   EventBackend eb;
 
   @POST
-  @Consumes(MediaType.APPLICATION_JSON)
   @Operation(summary = "Create a single event.",
           tags = {"event"},
           description = "Creates a single event.",

--- a/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/LdapUserResource.java
+++ b/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/LdapUserResource.java
@@ -38,7 +38,6 @@ public class LdapUserResource extends RestResource {
   }
 
   @POST
-  @Consumes(MediaType.APPLICATION_JSON)
   public Response createLdapUser(
       @Context UriInfo uriInfo, UserRepresentation content, @BeanParam UserParameters params)
       throws Exception {

--- a/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/LdapUserResource.java
+++ b/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/LdapUserResource.java
@@ -14,15 +14,16 @@ import org.oscm.rest.identity.data.UserRepresentation;
 
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
-import javax.ws.rs.*;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/ldapusers")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class LdapUserResource extends RestResource {
 
@@ -37,7 +38,6 @@ public class LdapUserResource extends RestResource {
   }
 
   @POST
-  @Consumes(MediaType.APPLICATION_JSON)
   public Response createLdapUser(
       @Context UriInfo uriInfo, UserRepresentation content, @BeanParam UserParameters params)
       throws Exception {

--- a/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/OnBehalfUserResource.java
+++ b/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/OnBehalfUserResource.java
@@ -44,7 +44,6 @@ public class OnBehalfUserResource extends RestResource {
   UserBackend ub;
 
   @POST
-  @Consumes(MediaType.APPLICATION_JSON)
   @Operation(summary = "Create a single on behalf user",
           tags = {"onbehalfusers"},
           description = "Creates a single on behalf user",

--- a/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/OnBehalfUserResource.java
+++ b/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/OnBehalfUserResource.java
@@ -26,15 +26,16 @@ import org.oscm.rest.identity.data.OnBehalfUserRepresentation;
 
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
-import javax.ws.rs.*;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/onbehalfusers")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class OnBehalfUserResource extends RestResource {
 
@@ -43,7 +44,6 @@ public class OnBehalfUserResource extends RestResource {
   UserBackend ub;
 
   @POST
-  @Consumes(MediaType.APPLICATION_JSON)
   @Operation(summary = "Create a single on behalf user",
           tags = {"onbehalfusers"},
           description = "Creates a single on behalf user",

--- a/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/RolesResource.java
+++ b/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/RolesResource.java
@@ -60,7 +60,6 @@ public class RolesResource extends RestResource {
   }
 
   @PUT
-  @Consumes(MediaType.APPLICATION_JSON)
   @Operation(summary = "Update a single role of user",
           tags = {"roles"},
           description = "Updates a single role of user",

--- a/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/RolesResource.java
+++ b/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/RolesResource.java
@@ -25,15 +25,16 @@ import org.oscm.rest.identity.data.RolesRepresentation;
 
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
-import javax.ws.rs.*;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/users/{userId}/userroles")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class RolesResource extends RestResource {
 
@@ -59,7 +60,6 @@ public class RolesResource extends RestResource {
   }
 
   @PUT
-  @Consumes(MediaType.APPLICATION_JSON)
   @Operation(summary = "Update a single role of user",
           tags = {"roles"},
           description = "Updates a single role of user",

--- a/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/UserResource.java
+++ b/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/UserResource.java
@@ -28,13 +28,11 @@ import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/users")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class UserResource extends RestResource {
 
@@ -58,23 +56,22 @@ public class UserResource extends RestResource {
     return getCollection(uriInfo, ub.getUsers(), params);
   }
 
-    @GET
-    @Path(PATH_USERID)
-    @Operation(summary = "Get a single user",
-            tags = {"users"},
-            description = "Returns a single user",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "A single user", content = @Content(
-                            schema = @Schema(implementation = UserRepresentation.class)
-                    ))
-            })
-    public Response getUser(@Context UriInfo uriInfo, @BeanParam UserParameters params)
-            throws Exception {
-        return get(uriInfo, ub.getUser(), params, false);
-    }
+   @GET
+   @Path(PATH_USERID)
+   @Operation(summary = "Get a single user",
+           tags = {"users"},
+           description = "Returns a single user",
+           responses = {
+                   @ApiResponse(responseCode = "200", description = "A single user", content = @Content(
+                           schema = @Schema(implementation = UserRepresentation.class)
+                   ))
+           })
+   public Response getUser(@Context UriInfo uriInfo, @BeanParam UserParameters params)
+           throws Exception {
+       return get(uriInfo, ub.getUser(), params, false);
+   }
 
   @POST
-  @Consumes(MediaType.APPLICATION_JSON)
   @Operation(summary = "Create a user",
           tags = {"users"},
           description = "Creates a user",

--- a/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/UserResource.java
+++ b/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/UserResource.java
@@ -72,7 +72,6 @@ public class UserResource extends RestResource {
    }
 
   @POST
-  @Consumes(MediaType.APPLICATION_JSON)
   @Operation(summary = "Create a user",
           tags = {"users"},
           description = "Creates a user",

--- a/oscm-rest-api-marketplace/src/main/java/org/oscm/rest/marketplace/EntryResource.java
+++ b/oscm-rest-api-marketplace/src/main/java/org/oscm/rest/marketplace/EntryResource.java
@@ -27,7 +27,6 @@ import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/marketplaces" + CommonParams.PATH_ID + "/entries/{sKey}")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class EntryResource extends RestResource {
 

--- a/oscm-rest-api-marketplace/src/main/java/org/oscm/rest/marketplace/EntryResource.java
+++ b/oscm-rest-api-marketplace/src/main/java/org/oscm/rest/marketplace/EntryResource.java
@@ -18,15 +18,15 @@ import org.oscm.rest.marketplace.data.EntryRepresentation;
 
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
-import javax.ws.rs.*;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/marketplaces" + CommonParams.PATH_ID + "/entries/{sKey}")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class EntryResource extends RestResource {
 
@@ -35,7 +35,6 @@ public class EntryResource extends RestResource {
   EntryBackend eb;
 
   @PUT
-  @Consumes(MediaType.APPLICATION_JSON)
   public Response updateCatalogEntry(
           @Context UriInfo uriInfo,
           EntryRepresentation content,

--- a/oscm-rest-api-marketplace/src/main/java/org/oscm/rest/marketplace/MarketplaceResource.java
+++ b/oscm-rest-api-marketplace/src/main/java/org/oscm/rest/marketplace/MarketplaceResource.java
@@ -20,13 +20,11 @@ import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/marketplaces")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class MarketplaceResource extends RestResource {
 
@@ -40,8 +38,14 @@ public class MarketplaceResource extends RestResource {
     return getCollection(uriInfo, mb.getCollection(), params);
   }
 
+  @GET
+  @Path(CommonParams.PATH_ID)
+  public Response getMarketplace(@Context UriInfo uriInfo, @BeanParam MarketplaceParameters params)
+          throws Exception {
+    return get(uriInfo, mb.get(), params, true);
+  }
+
   @POST
-  @Consumes(MediaType.APPLICATION_JSON)
   public Response createMarketplace(
       @Context UriInfo uriInfo,
       MarketplaceRepresentation content,
@@ -50,15 +54,7 @@ public class MarketplaceResource extends RestResource {
     return post(uriInfo, mb.post(), content, params);
   }
 
-  @GET
-  @Path(CommonParams.PATH_ID)
-  public Response getMarketplace(@Context UriInfo uriInfo, @BeanParam MarketplaceParameters params)
-      throws Exception {
-    return get(uriInfo, mb.get(), params, true);
-  }
-
   @PUT
-  @Consumes(MediaType.APPLICATION_JSON)
   @Path(CommonParams.PATH_ID)
   public Response updateMarketplace(
       @Context UriInfo uriInfo,

--- a/oscm-rest-api-marketplace/src/main/java/org/oscm/rest/marketplace/MarketplaceResource.java
+++ b/oscm-rest-api-marketplace/src/main/java/org/oscm/rest/marketplace/MarketplaceResource.java
@@ -25,7 +25,6 @@ import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/marketplaces")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class MarketplaceResource extends RestResource {
 

--- a/oscm-rest-api-operation/src/main/java/org/oscm/rest/operation/SettingsResource.java
+++ b/oscm-rest-api-operation/src/main/java/org/oscm/rest/operation/SettingsResource.java
@@ -20,13 +20,11 @@ import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/settings")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class SettingsResource extends RestResource {
 
@@ -41,8 +39,14 @@ public class SettingsResource extends RestResource {
     return getCollection(uriInfo, sb.getCollection(), params);
   }
 
+  @GET
+  @Path(CommonParams.PATH_ID)
+  public Response getSetting(@Context UriInfo uriInfo, @BeanParam OperationParameters params)
+          throws Exception {
+    return get(uriInfo, sb.get(), params, true);
+  }
+
   @POST
-  @Consumes(MediaType.APPLICATION_JSON)
   public Response createSetting(
       @Context UriInfo uriInfo,
       SettingRepresentation content,
@@ -51,15 +55,8 @@ public class SettingsResource extends RestResource {
     return post(uriInfo, sb.post(), content, params);
   }
 
-  @GET
-  @Path(CommonParams.PATH_ID)
-  public Response getSetting(@Context UriInfo uriInfo, @BeanParam OperationParameters params)
-      throws Exception {
-    return get(uriInfo, sb.get(), params, true);
-  }
 
   @PUT
-  @Consumes(MediaType.APPLICATION_JSON)
   @Path(CommonParams.PATH_ID)
   public Response updateSetting(
       @Context UriInfo uriInfo,

--- a/oscm-rest-api-operation/src/main/java/org/oscm/rest/operation/SettingsResource.java
+++ b/oscm-rest-api-operation/src/main/java/org/oscm/rest/operation/SettingsResource.java
@@ -33,7 +33,6 @@ import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/settings")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class SettingsResource extends RestResource {
 

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/CompatibleServiceResource.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/CompatibleServiceResource.java
@@ -19,15 +19,16 @@ import org.oscm.rest.service.data.ServiceRepresentation;
 
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
-import javax.ws.rs.*;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/services" + CommonParams.PATH_ID + "/compatibleservices")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class CompatibleServiceResource extends RestResource {
 
@@ -43,7 +44,6 @@ public class CompatibleServiceResource extends RestResource {
   }
 
   @PUT
-  @Consumes(MediaType.APPLICATION_JSON)
   public Response setCompatibleServices(
       @Context UriInfo uriInfo,
       RepresentationCollection<ServiceRepresentation> content,

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/PriceModelResource.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/PriceModelResource.java
@@ -18,15 +18,16 @@ import org.oscm.rest.service.data.PriceModelRepresentation;
 
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
-import javax.ws.rs.*;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/services" + CommonParams.PATH_ID + "/pricemodel")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class PriceModelResource extends RestResource {
 
@@ -40,8 +41,14 @@ public class PriceModelResource extends RestResource {
     return get(uriInfo, pmb.get(), params, true);
   }
 
+  @GET
+  @Path("/customer/{orgKey}")
+  public Response getForCustomer(@Context UriInfo uriInfo, @BeanParam ServiceParameters params)
+          throws Exception {
+    return get(uriInfo, pmb.getForCustomer(), params, true);
+  }
+
   @PUT
-  @Consumes(MediaType.APPLICATION_JSON)
   public Response update(
       @Context UriInfo uriInfo,
       PriceModelRepresentation content,
@@ -50,15 +57,7 @@ public class PriceModelResource extends RestResource {
     return put(uriInfo, pmb.put(), content, params);
   }
 
-  @GET
-  @Path("/customer/{orgKey}")
-  public Response getForCustomer(@Context UriInfo uriInfo, @BeanParam ServiceParameters params)
-      throws Exception {
-    return get(uriInfo, pmb.getForCustomer(), params, true);
-  }
-
   @PUT
-  @Consumes(MediaType.APPLICATION_JSON)
   @Path("/customer/{orgKey}")
   public Response updateForCustomer(
       @Context UriInfo uriInfo,

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/PriceModelResource.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/PriceModelResource.java
@@ -28,7 +28,6 @@ import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/services" + CommonParams.PATH_ID + "/pricemodel")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class PriceModelResource extends RestResource {
 

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/ServiceResource.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/ServiceResource.java
@@ -21,13 +21,11 @@ import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/services")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class ServiceResource extends RestResource {
 
@@ -41,8 +39,14 @@ public class ServiceResource extends RestResource {
     return getCollection(uriInfo, sb.getCollection(), params);
   }
 
+  @GET
+  @Path(CommonParams.PATH_ID)
+  public Response getService(@Context UriInfo uriInfo, @BeanParam ServiceParameters params)
+          throws Exception {
+    return get(uriInfo, sb.get(), params, true);
+  }
+
   @POST
-  @Consumes(MediaType.APPLICATION_JSON)
   public Response createService(
       @Context UriInfo uriInfo,
       ServiceDetailsRepresentation content,
@@ -51,15 +55,7 @@ public class ServiceResource extends RestResource {
     return post(uriInfo, sb.post(), content, params);
   }
 
-  @GET
-  @Path(CommonParams.PATH_ID)
-  public Response getService(@Context UriInfo uriInfo, @BeanParam ServiceParameters params)
-      throws Exception {
-    return get(uriInfo, sb.get(), params, true);
-  }
-
   @PUT
-  @Consumes(MediaType.APPLICATION_JSON)
   @Path(CommonParams.PATH_ID)
   public Response updateService(
       @Context UriInfo uriInfo,
@@ -77,7 +73,6 @@ public class ServiceResource extends RestResource {
   }
 
   @PUT
-  @Consumes(MediaType.APPLICATION_JSON)
   @Path(CommonParams.PATH_ID + "/status")
   public Response setServiceState(
       @Context UriInfo uriInfo, StatusRepresentation content, @BeanParam ServiceParameters params)

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/ServiceResource.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/ServiceResource.java
@@ -26,7 +26,6 @@ import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/services")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class ServiceResource extends RestResource {
 

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TSSupplierResource.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TSSupplierResource.java
@@ -25,7 +25,6 @@ import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/technicalservices" + CommonParams.PATH_ID + "/suppliers")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class TSSupplierResource extends RestResource {
 

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TSSupplierResource.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TSSupplierResource.java
@@ -20,13 +20,11 @@ import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/technicalservices" + CommonParams.PATH_ID + "/suppliers")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class TSSupplierResource extends RestResource {
 
@@ -41,7 +39,6 @@ public class TSSupplierResource extends RestResource {
   }
 
   @POST
-  @Consumes(MediaType.APPLICATION_JSON)
   public Response addSupplier(
       @Context UriInfo uriInfo,
       OrganizationRepresentation content,

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TechnicalServiceResource.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TechnicalServiceResource.java
@@ -31,7 +31,6 @@ import java.util.Collections;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/technicalservices")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class TechnicalServiceResource extends RestResource {
 
@@ -47,27 +46,10 @@ public class TechnicalServiceResource extends RestResource {
     return getCollection(uriInfo, tsb.getCollection(), params);
   }
 
-  @POST
-  @Consumes(MediaType.APPLICATION_JSON)
-  public Response createTechnicalService(
-      @Context UriInfo uriInfo,
-      TechnicalServiceRepresentation content,
-      @BeanParam ServiceParameters params)
-      throws Exception {
-    return post(uriInfo, tsb.post(), content, params);
-  }
-
-  @DELETE
-  @Path(CommonParams.PATH_ID)
-  public Response deleteTechnicalService(
-      @Context UriInfo uriInfo, @BeanParam ServiceParameters params) throws Exception {
-    return delete(uriInfo, tsb.delete(), params);
-  }
-
   @GET
   @Path(CommonParams.PATH_ID)
   public Response exportTechnicalService(
-      @Context UriInfo uriInfo, @BeanParam ServiceParameters params) throws Exception {
+          @Context UriInfo uriInfo, @BeanParam ServiceParameters params) throws Exception {
     // FIXME: Implement this endpoint properly. Use get() from interface
     // key needed
     VOTechnicalService ts = new VOTechnicalService();
@@ -76,11 +58,19 @@ public class TechnicalServiceResource extends RestResource {
     return Response.ok(export, MediaType.APPLICATION_XML_TYPE).build();
   }
 
-  @PUT
-  @Consumes(MediaType.APPLICATION_JSON)
-  public Response importTechnicalServices(
-      @Context UriInfo uriInfo, byte[] input, @BeanParam ServiceParameters params)
+  @POST
+  public Response createTechnicalService(
+      @Context UriInfo uriInfo,
+      TechnicalServiceRepresentation content,
+      @BeanParam ServiceParameters params)
       throws Exception {
+    return post(uriInfo, tsb.post(), content, params);
+  }
+
+  @PUT
+  public Response importTechnicalServices(
+          @Context UriInfo uriInfo, byte[] input, @BeanParam ServiceParameters params)
+          throws Exception {
     // FIXME: Implement this endpoint properly. Use put() from interface
     // FIXME: This endpoint should accept TSRepresentation instead of byte array (just like every
     // other  PUT endpoint)
@@ -89,5 +79,12 @@ public class TechnicalServiceResource extends RestResource {
       return Response.noContent().build();
     }
     return Response.status(Status.BAD_REQUEST).entity(msg).build();
+  }
+
+  @DELETE
+  @Path(CommonParams.PATH_ID)
+  public Response deleteTechnicalService(
+      @Context UriInfo uriInfo, @BeanParam ServiceParameters params) throws Exception {
+    return delete(uriInfo, tsb.delete(), params);
   }
 }

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TechnicalServiceResource.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TechnicalServiceResource.java
@@ -31,7 +31,6 @@ import java.util.Collections;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/technicalservices")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class TechnicalServiceResource extends RestResource {
 

--- a/oscm-rest-api-subscription/src/main/java/org/oscm/rest/subscription/SubscriptionResource.java
+++ b/oscm-rest-api-subscription/src/main/java/org/oscm/rest/subscription/SubscriptionResource.java
@@ -26,7 +26,6 @@ import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/subscriptions")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class SubscriptionResource extends RestResource {
 
@@ -40,8 +39,14 @@ public class SubscriptionResource extends RestResource {
     return getCollection(uriInfo, sb.getCollection(), params);
   }
 
+  @GET
+  @Path(CommonParams.PATH_ID)
+  public Response getSubscription(
+          @Context UriInfo uriInfo, @BeanParam SubscriptionParameters params) throws Exception {
+    return get(uriInfo, sb.get(), params, true);
+  }
+
   @POST
-  @Consumes(MediaType.APPLICATION_JSON)
   public Response createSubscription(
       @Context UriInfo uriInfo,
       SubscriptionCreationRepresentation content,
@@ -50,15 +55,7 @@ public class SubscriptionResource extends RestResource {
     return post(uriInfo, sb.post(), content, params);
   }
 
-  @GET
-  @Path(CommonParams.PATH_ID)
-  public Response getSubscription(
-      @Context UriInfo uriInfo, @BeanParam SubscriptionParameters params) throws Exception {
-    return get(uriInfo, sb.get(), params, true);
-  }
-
   @PUT
-  @Consumes(MediaType.APPLICATION_JSON)
   @Path(CommonParams.PATH_ID)
   public Response updateSubscription(
       @Context UriInfo uriInfo,

--- a/oscm-rest-api-subscription/src/main/java/org/oscm/rest/subscription/UsageLicenseResource.java
+++ b/oscm-rest-api-subscription/src/main/java/org/oscm/rest/subscription/UsageLicenseResource.java
@@ -20,13 +20,11 @@ import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 @Since(CommonParams.VERSION_1)
 @Path(CommonParams.PATH_VERSION + "/subscriptions" + CommonParams.PATH_ID + "/usagelicenses")
-@Produces(MediaType.APPLICATION_JSON)
 @Stateless
 public class UsageLicenseResource extends RestResource {
 
@@ -35,14 +33,12 @@ public class UsageLicenseResource extends RestResource {
   UsageLicenseBackend ulb;
 
   @GET
-  @Produces(MediaType.APPLICATION_JSON)
   public Response getLicenses(@Context UriInfo uriInfo, @BeanParam SubscriptionParameters params)
       throws Exception {
     return getCollection(uriInfo, ulb.getCollection(), params);
   }
 
   @POST
-  @Consumes(MediaType.APPLICATION_JSON)
   public Response createLicense(
       @Context UriInfo uriInfo,
       UsageLicenseRepresentation content,
@@ -52,7 +48,6 @@ public class UsageLicenseResource extends RestResource {
   }
 
   @PUT
-  @Consumes(MediaType.APPLICATION_JSON)
   @Path("/{licKey}")
   public Response updateLicense(
       @Context UriInfo uriInfo,


### PR DESCRIPTION
In this pull request:
- Moved redundant annotations (Since and Produces) to class-level
- Added missing Consumes annotation where appropriate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm-rest-api/114)
<!-- Reviewable:end -->
