### PR TITLE
Remove id from PUT body examples where it is already fixed

### DIFF
--- a/oscm-rest-api-common/src/main/java/constants/AccountConstants.java
+++ b/oscm-rest-api-common/src/main/java/constants/AccountConstants.java
@@ -93,7 +93,6 @@ public class AccountConstants {
             "\"infoId\": \"DIRECT_DEBIT\",\n" +
             "\"providerName\": \"provname\",\n" +
             "\"accountNumer\": 12345,\n" +
-            "\"id\": 10000,\n" +
             "\"etag\": 2 \n" +
             "}";
 

--- a/oscm-rest-api-common/src/main/java/constants/IdentityConstants.java
+++ b/oscm-rest-api-common/src/main/java/constants/IdentityConstants.java
@@ -35,6 +35,7 @@ public class IdentityConstants {
             "\"etag\": 0,\n" +
             "\"id\": 13010\n" +
             "}";
+
     public static final String USER_MINIMUM_BODY = "{\n" +
             "\"email\": \"test@email.com\",\n" +
             "\"locale\": \"ja\",\n" +

--- a/oscm-rest-api-common/src/main/java/constants/OperationConstants.java
+++ b/oscm-rest-api-common/src/main/java/constants/OperationConstants.java
@@ -28,7 +28,6 @@ public class OperationConstants {
             "\"informationId\": \"MP_ERROR_REDIRECT_HTTPS\",\n" +
             "\"contextId\": \"global\",\n" +
             "\"value\": \"https://redirect.com\",\n" +
-            "\"etag\": 0,\n" +
-            "\"id\": 15\n" +
+            "\"etag\": 0\n" +
             "}";
 }

--- a/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/RolesResource.java
+++ b/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/RolesResource.java
@@ -60,9 +60,9 @@ public class RolesResource extends RestResource {
   }
 
   @PUT
-  @Operation(summary = "Update a single role of user",
+  @Operation(summary = "Update a single role of a user",
           tags = {"roles"},
-          description = "Updates a single role of user",
+          description = "Updates a single role of a user",
           requestBody = @RequestBody(
                   description = "RolesRepresentation object to be updated",
                   required = true,


### PR DESCRIPTION
In this pull request:
- Updates swagger documentation after fixing an issue with ID not passed from URI in the PUT methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm-rest-api/133)
<!-- Reviewable:end -->
