### PR TITLE
BugFix: Make licKey a mandatory PathParam in the Swagger UI

### DIFF
--- a/oscm-rest-api-common/src/main/java/org/oscm/rest/common/requestparameters/SubscriptionParameters.java
+++ b/oscm-rest-api-common/src/main/java/org/oscm/rest/common/requestparameters/SubscriptionParameters.java
@@ -9,6 +9,9 @@
  */
 package org.oscm.rest.common.requestparameters;
 
+import io.swagger.v3.oas.annotations.Parameter;
+
+import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 
@@ -17,7 +20,8 @@ public class SubscriptionParameters extends RequestParameters {
   @QueryParam("userId")
   private String userId;
 
-  @QueryParam("licKey")
+  @Parameter(description = "Subscription's usage license key", required = true)
+  @PathParam("licKey")
   private Long licKey;
 
   @Override


### PR DESCRIPTION
In this PR:
  - Fix for bug: https://github.com/servicecatalog/oscm-rest-api/issues/166

[x] Changes tested manually

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm-rest-api/167)
<!-- Reviewable:end -->
