### PR TITLE
Split RequestParameters into Non-Identifiable and Identifiable

### DIFF
--- a/oscm-rest-api-account/src/main/java/org/oscm/rest/account/AccountBackend.java
+++ b/oscm-rest-api-account/src/main/java/org/oscm/rest/account/AccountBackend.java
@@ -23,6 +23,7 @@ import org.oscm.internal.vo.VOPaymentInfo;
 import org.oscm.rest.common.RestBackend;
 import org.oscm.rest.common.representation.*;
 import org.oscm.rest.common.requestparameters.AccountParameters;
+import org.oscm.rest.common.requestparameters.IdentifiableAccountParameters;
 
 @Stateless
 public class AccountBackend {
@@ -47,7 +48,7 @@ public class AccountBackend {
     };
   }
 
-  public RestBackend.Get<BillingContactRepresentation, AccountParameters> getBillingContact() {
+  public RestBackend.Get<BillingContactRepresentation, IdentifiableAccountParameters> getBillingContact() {
     return params -> {
       BillingContactRepresentation item = null;
       List<VOBillingContact> list = as.getBillingContacts();
@@ -65,14 +66,14 @@ public class AccountBackend {
     };
   }
 
-  public RestBackend.Put<BillingContactRepresentation, AccountParameters> putBillingContact() {
+  public RestBackend.Put<BillingContactRepresentation, IdentifiableAccountParameters> putBillingContact() {
     return (content, params) -> {
       as.saveBillingContact(content.getVO());
       return true;
     };
   }
 
-  public RestBackend.Delete<AccountParameters> deleteBillingContact() {
+  public RestBackend.Delete<IdentifiableAccountParameters> deleteBillingContact() {
     return params -> {
       VOBillingContact bc = new VOBillingContact();
       bc.setKey(params.getId().longValue());
@@ -91,14 +92,14 @@ public class AccountBackend {
     };
   }
 
-  public RestBackend.Put<PaymentInfoRepresentation, AccountParameters> putPaymentInfo() {
+  public RestBackend.Put<PaymentInfoRepresentation, IdentifiableAccountParameters> putPaymentInfo() {
     return (content, params) -> {
       as.savePaymentInfo(content.getVO());
       return true;
     };
   }
 
-  public RestBackend.Get<PaymentInfoRepresentation, AccountParameters> getPaymentInfo() {
+  public RestBackend.Get<PaymentInfoRepresentation, IdentifiableAccountParameters> getPaymentInfo() {
     return params -> {
       PaymentInfoRepresentation item = null;
       List<VOPaymentInfo> list = as.getPaymentInfos();
@@ -116,7 +117,7 @@ public class AccountBackend {
     };
   }
 
-  public RestBackend.Delete<AccountParameters> deletePaymentInfo() {
+  public RestBackend.Delete<IdentifiableAccountParameters> deletePaymentInfo() {
     return params -> {
       VOPaymentInfo pi = new VOPaymentInfo();
       pi.setKey(params.getId().longValue());
@@ -165,7 +166,7 @@ public class AccountBackend {
     };
   }
 
-  public RestBackend.Get<OrganizationRepresentation, AccountParameters> getOrganization() {
+  public RestBackend.Get<OrganizationRepresentation, IdentifiableAccountParameters> getOrganization() {
     return params -> {
       VOOrganization org = as.getOrganizationData();
       OrganizationRepresentation item;

--- a/oscm-rest-api-account/src/main/java/org/oscm/rest/account/BillingContactResource.java
+++ b/oscm-rest-api-account/src/main/java/org/oscm/rest/account/BillingContactResource.java
@@ -30,6 +30,7 @@ import org.oscm.rest.common.RestResource;
 import org.oscm.rest.common.Since;
 import org.oscm.rest.common.representation.BillingContactRepresentation;
 import org.oscm.rest.common.requestparameters.AccountParameters;
+import org.oscm.rest.common.requestparameters.IdentifiableAccountParameters;
 
 @Path(CommonParams.PATH_VERSION + "/billingcontacts")
 @Stateless
@@ -73,7 +74,7 @@ public class BillingContactResource extends RestResource {
             content =
                 @Content(schema = @Schema(implementation = BillingContactRepresentation.class)))
       })
-  public Response getBillingContact(@Context UriInfo uriInfo, @BeanParam AccountParameters params)
+  public Response getBillingContact(@Context UriInfo uriInfo, @BeanParam IdentifiableAccountParameters params)
       throws Exception {
     return get(uriInfo, ab.getBillingContact(), params, true);
   }
@@ -142,7 +143,7 @@ public class BillingContactResource extends RestResource {
   public Response updateBillingContact(
       @Context UriInfo uriInfo,
       BillingContactRepresentation content,
-      @BeanParam AccountParameters params)
+      @BeanParam IdentifiableAccountParameters params)
       throws Exception {
     // FIXME: Move investigate why the same command doesn't work from RestResource#128
     content.setId(params.getId());
@@ -160,7 +161,7 @@ public class BillingContactResource extends RestResource {
         @ApiResponse(responseCode = "204", description = "Billing contact deleted successfully")
       })
   public Response deleteBillingContact(
-      @Context UriInfo uriInfo, @BeanParam AccountParameters params) throws Exception {
+      @Context UriInfo uriInfo, @BeanParam IdentifiableAccountParameters params) throws Exception {
     return delete(uriInfo, ab.deleteBillingContact(), params);
   }
 }

--- a/oscm-rest-api-account/src/main/java/org/oscm/rest/account/OrganizationResource.java
+++ b/oscm-rest-api-account/src/main/java/org/oscm/rest/account/OrganizationResource.java
@@ -34,6 +34,7 @@ import org.oscm.rest.common.Since;
 import org.oscm.rest.common.representation.AccountRepresentation;
 import org.oscm.rest.common.representation.OrganizationRepresentation;
 import org.oscm.rest.common.requestparameters.AccountParameters;
+import org.oscm.rest.common.requestparameters.IdentifiableAccountParameters;
 
 @Path(CommonParams.PATH_VERSION + "/organizations")
 @Stateless
@@ -56,7 +57,7 @@ public class OrganizationResource extends RestResource {
             description = "The organization",
             content = @Content(schema = @Schema(implementation = OrganizationRepresentation.class)))
       })
-  public Response getOrganization(@Context UriInfo uriInfo, @BeanParam AccountParameters params)
+  public Response getOrganization(@Context UriInfo uriInfo, @BeanParam IdentifiableAccountParameters params)
       throws Exception {
     return get(uriInfo, ab.getOrganization(), params, true);
   }

--- a/oscm-rest-api-account/src/main/java/org/oscm/rest/account/PaymentInfoResource.java
+++ b/oscm-rest-api-account/src/main/java/org/oscm/rest/account/PaymentInfoResource.java
@@ -30,6 +30,7 @@ import org.oscm.rest.common.RestResource;
 import org.oscm.rest.common.Since;
 import org.oscm.rest.common.representation.PaymentInfoRepresentation;
 import org.oscm.rest.common.requestparameters.AccountParameters;
+import org.oscm.rest.common.requestparameters.IdentifiableAccountParameters;
 
 @Path(CommonParams.PATH_VERSION + "/paymentinfos")
 @Stateless
@@ -69,7 +70,7 @@ public class PaymentInfoResource extends RestResource {
             description = "A single payment info",
             content = @Content(schema = @Schema(implementation = PaymentInfoRepresentation.class)))
       })
-  public Response getPaymentInfo(@Context UriInfo uriInfo, @BeanParam AccountParameters params)
+  public Response getPaymentInfo(@Context UriInfo uriInfo, @BeanParam IdentifiableAccountParameters params)
       throws Exception {
     return get(uriInfo, ab.getPaymentInfo(), params, true);
   }
@@ -110,7 +111,7 @@ public class PaymentInfoResource extends RestResource {
   public Response updatePaymentInfo(
       @Context UriInfo uriInfo,
       PaymentInfoRepresentation content,
-      @BeanParam AccountParameters params)
+      @BeanParam IdentifiableAccountParameters params)
       throws Exception {
     return put(uriInfo, ab.putPaymentInfo(), content, params);
   }
@@ -125,7 +126,7 @@ public class PaymentInfoResource extends RestResource {
       responses = {
         @ApiResponse(responseCode = "204", description = "Payment info deleted successfully")
       })
-  public Response deletePaymentInfo(@Context UriInfo uriInfo, @BeanParam AccountParameters params)
+  public Response deletePaymentInfo(@Context UriInfo uriInfo, @BeanParam IdentifiableAccountParameters params)
       throws Exception {
     return delete(uriInfo, ab.deletePaymentInfo(), params);
   }

--- a/oscm-rest-api-account/src/test/java/org/oscm/rest/account/AccountBackendTest.java
+++ b/oscm-rest-api-account/src/test/java/org/oscm/rest/account/AccountBackendTest.java
@@ -29,6 +29,7 @@ import org.oscm.rest.common.TestContants;
 import org.oscm.rest.common.representation.*;
 import org.oscm.rest.common.SampleTestDataUtility;
 import org.oscm.rest.common.requestparameters.AccountParameters;
+import org.oscm.rest.common.requestparameters.IdentifiableAccountParameters;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -51,6 +52,7 @@ public class AccountBackendTest {
 
   private UriInfo uriInfo;
   private AccountParameters parameters;
+  private IdentifiableAccountParameters indentifiableParameters;
   private BillingContactRepresentation billingContactRepresentation;
   private PaymentInfoRepresentation paymentInfoRepresentation;
   private VOBillingContact billingContactVO;
@@ -68,6 +70,7 @@ public class AccountBackendTest {
 
     uriInfo = SampleTestDataUtility.createUriInfo();
     parameters = SampleTestDataUtility.createAccountParameters();
+    indentifiableParameters = SampleTestDataUtility.createIdentifiableAccountParameters();
     billingContactRepresentation = SampleTestDataUtility.createBillingContactRepresentation();
     paymentInfoRepresentation = SampleTestDataUtility.createPaymentInfoRepresentation();
     billingContactVO = SampleTestDataUtility.createBillingContactVO();
@@ -100,7 +103,7 @@ public class AccountBackendTest {
   public void shouldGetBillingContact() {
     when(accountService.getBillingContacts()).thenReturn(Lists.newArrayList(billingContactVO));
 
-    Response response = billingContactResource.getBillingContact(uriInfo, parameters);
+    Response response = billingContactResource.getBillingContact(uriInfo, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -131,7 +134,7 @@ public class AccountBackendTest {
 
     Response response =
         billingContactResource.updateBillingContact(
-            uriInfo, billingContactRepresentation, parameters);
+            uriInfo, billingContactRepresentation, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -144,7 +147,7 @@ public class AccountBackendTest {
   public void shouldDeleteBillingContact() {
     doNothing().when(accountService).deleteBillingContact(any());
 
-    Response response = billingContactResource.deleteBillingContact(uriInfo, parameters);
+    Response response = billingContactResource.deleteBillingContact(uriInfo, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -177,7 +180,7 @@ public class AccountBackendTest {
   public void shouldGetPaymentInfo() {
     when(accountService.getPaymentInfos()).thenReturn(Lists.newArrayList(paymentInfoVO));
 
-    Response response = paymentInfoResource.getPaymentInfo(uriInfo, parameters);
+    Response response = paymentInfoResource.getPaymentInfo(uriInfo, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -192,7 +195,7 @@ public class AccountBackendTest {
     when(accountService.savePaymentInfo(any())).thenReturn(paymentInfoVO);
 
     Response response =
-        paymentInfoResource.updatePaymentInfo(uriInfo, paymentInfoRepresentation, parameters);
+        paymentInfoResource.updatePaymentInfo(uriInfo, paymentInfoRepresentation, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -205,7 +208,7 @@ public class AccountBackendTest {
   public void shouldDeletePaymentInfo() {
     doNothing().when(accountService).deletePaymentInfo(any());
 
-    Response response = paymentInfoResource.deletePaymentInfo(uriInfo, parameters);
+    Response response = paymentInfoResource.deletePaymentInfo(uriInfo, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -219,7 +222,7 @@ public class AccountBackendTest {
     when(operatorService.getOrganization(any())).thenReturn(operatorOrgVO);
     when(accountService.getOrganizationData()).thenReturn(operatorOrgVO);
 
-    Response response = organizationResource.getOrganization(uriInfo, parameters);
+    Response response = organizationResource.getOrganization(uriInfo, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)

--- a/oscm-rest-api-account/src/test/java/org/oscm/rest/account/BillingContactResourceTest.java
+++ b/oscm-rest-api-account/src/test/java/org/oscm/rest/account/BillingContactResourceTest.java
@@ -22,6 +22,7 @@ import org.oscm.rest.common.representation.BillingContactRepresentation;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.SampleTestDataUtility;
 import org.oscm.rest.common.requestparameters.AccountParameters;
+import org.oscm.rest.common.requestparameters.IdentifiableAccountParameters;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -39,6 +40,7 @@ public class BillingContactResourceTest {
   private BillingContactRepresentation representation;
   private UriInfo uriInfo;
   private AccountParameters parameters;
+  private IdentifiableAccountParameters indentifiableParameters;
 
   private Response result;
 
@@ -47,6 +49,7 @@ public class BillingContactResourceTest {
     representation = SampleTestDataUtility.createBillingContactRepresentation();
     uriInfo = SampleTestDataUtility.createUriInfo();
     parameters = SampleTestDataUtility.createAccountParameters();
+    indentifiableParameters = SampleTestDataUtility.createIdentifiableAccountParameters();
   }
 
   @AfterEach
@@ -103,7 +106,7 @@ public class BillingContactResourceTest {
     when(accountBackend.getBillingContact()).thenReturn((accountParameters -> representation));
 
     try {
-      result = resource.getBillingContact(uriInfo, parameters);
+      result = resource.getBillingContact(uriInfo, indentifiableParameters);
     } catch (Exception e) {
       fail(e);
     }
@@ -121,7 +124,7 @@ public class BillingContactResourceTest {
         .thenReturn(((billingContactRepresentation, accountParameters) -> true));
 
     try {
-      result = resource.updateBillingContact(uriInfo, representation, parameters);
+      result = resource.updateBillingContact(uriInfo, representation, indentifiableParameters);
     } catch (Exception e) {
       fail(e);
     }
@@ -137,7 +140,7 @@ public class BillingContactResourceTest {
     when(accountBackend.deleteBillingContact()).thenReturn((accountParameters -> true));
 
     try {
-      result = resource.deleteBillingContact(uriInfo, parameters);
+      result = resource.deleteBillingContact(uriInfo, indentifiableParameters);
     } catch (Exception e) {
       fail(e);
     }

--- a/oscm-rest-api-account/src/test/java/org/oscm/rest/account/OrganizationResourceTest.java
+++ b/oscm-rest-api-account/src/test/java/org/oscm/rest/account/OrganizationResourceTest.java
@@ -22,6 +22,7 @@ import org.oscm.rest.common.representation.OrganizationRepresentation;
 import org.oscm.rest.common.representation.UserRepresentation;
 import org.oscm.rest.common.SampleTestDataUtility;
 import org.oscm.rest.common.requestparameters.AccountParameters;
+import org.oscm.rest.common.requestparameters.IdentifiableAccountParameters;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -42,6 +43,7 @@ public class OrganizationResourceTest {
   private OrganizationRepresentation orgRepresentation;
   private UriInfo uriInfo;
   private AccountParameters parameters;
+  private IdentifiableAccountParameters indentifiableParameters;
   private Response result;
 
   @BeforeEach
@@ -50,6 +52,7 @@ public class OrganizationResourceTest {
     orgRepresentation = SampleTestDataUtility.createOrgRepresentation();
     uriInfo = SampleTestDataUtility.createUriInfo();
     parameters = SampleTestDataUtility.createAccountParameters();
+    indentifiableParameters = SampleTestDataUtility.createIdentifiableAccountParameters();
   }
 
   @AfterEach
@@ -79,7 +82,7 @@ public class OrganizationResourceTest {
     when(backend.getOrganization()).thenReturn((accountParameters -> orgRepresentation));
 
     try {
-      result = resource.getOrganization(uriInfo, parameters);
+      result = resource.getOrganization(uriInfo, indentifiableParameters);
     } catch (Exception e) {
       fail(e);
     }

--- a/oscm-rest-api-account/src/test/java/org/oscm/rest/account/PaymentInfoResourceTest.java
+++ b/oscm-rest-api-account/src/test/java/org/oscm/rest/account/PaymentInfoResourceTest.java
@@ -22,6 +22,7 @@ import org.oscm.rest.common.representation.PaymentInfoRepresentation;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.SampleTestDataUtility;
 import org.oscm.rest.common.requestparameters.AccountParameters;
+import org.oscm.rest.common.requestparameters.IdentifiableAccountParameters;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -39,12 +40,14 @@ public class PaymentInfoResourceTest {
   private PaymentInfoRepresentation paymentInfoRepresentation;
   private UriInfo uriInfo;
   private AccountParameters parameters;
+  private IdentifiableAccountParameters indentifiableParameters;
   private Response result;
 
   @BeforeEach
   public void setUp() {
     paymentInfoRepresentation = SampleTestDataUtility.createPIRepresentation();
     parameters = SampleTestDataUtility.createAccountParameters();
+    indentifiableParameters = SampleTestDataUtility.createIdentifiableAccountParameters();
     uriInfo = SampleTestDataUtility.createUriInfo();
   }
 
@@ -85,7 +88,7 @@ public class PaymentInfoResourceTest {
     when(backend.getPaymentInfo()).thenReturn((accountParameters -> paymentInfoRepresentation));
 
     try {
-      result = resource.getPaymentInfo(uriInfo, parameters);
+      result = resource.getPaymentInfo(uriInfo, indentifiableParameters);
     } catch (Exception e) {
       fail(e);
     }
@@ -103,7 +106,7 @@ public class PaymentInfoResourceTest {
         .thenReturn(((paymentInfoRepresentation1, accountParameters) -> true));
 
     try {
-      result = resource.updatePaymentInfo(uriInfo, paymentInfoRepresentation, parameters);
+      result = resource.updatePaymentInfo(uriInfo, paymentInfoRepresentation, indentifiableParameters);
     } catch (Exception e) {
       fail(e);
     }
@@ -119,7 +122,7 @@ public class PaymentInfoResourceTest {
     when(backend.deletePaymentInfo()).thenReturn((accountParameters -> true));
 
     try {
-      result = resource.deletePaymentInfo(uriInfo, parameters);
+      result = resource.deletePaymentInfo(uriInfo, indentifiableParameters);
     } catch (Exception e) {
       fail(e);
     }

--- a/oscm-rest-api-common/src/main/java/org/oscm/rest/common/RestResource.java
+++ b/oscm-rest-api-common/src/main/java/org/oscm/rest/common/RestResource.java
@@ -9,21 +9,24 @@
  */
 package org.oscm.rest.common;
 
-import static org.oscm.rest.common.CommonParams.PARAM_VERSION;
-
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.security.SecuritySchemes;
-import java.util.List;
+import org.oscm.rest.common.representation.Representation;
+import org.oscm.rest.common.requestparameters.IdentifableRequestParameters;
+import org.oscm.rest.common.requestparameters.RequestParameters;
+import org.oscm.rest.common.requestparameters.UserParameters;
+
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-import org.oscm.rest.common.representation.Representation;
-import org.oscm.rest.common.requestparameters.RequestParameters;
+import java.util.List;
+
+import static org.oscm.rest.common.CommonParams.PARAM_VERSION;
 
 /**
  * Super class for REST resources and their endpoints.
@@ -147,7 +150,9 @@ public abstract class RestResource {
     prepareData(version, params, true, content, true);
 
     if (content != null) {
-      content.setId(params.getId());
+      if(params instanceof IdentifableRequestParameters) {
+        content.setId(((IdentifableRequestParameters) params).getId());
+      }
       content.setETag(params.getETag());
     }
 
@@ -207,8 +212,8 @@ public abstract class RestResource {
       int version, RequestParameters params, boolean withId, Representation rep, boolean withRep)
       throws WebApplicationException {
 
-    if (withId) {
-      params.validateId();
+    if (withId && params instanceof IdentifableRequestParameters) {
+      ((IdentifableRequestParameters) params).validateId();
     }
 
     params.validateETag();
@@ -226,8 +231,8 @@ public abstract class RestResource {
       rep.validateContent();
       rep.setVersion(version);
 
-      if (withId) {
-        rep.setId(params.getId());
+      if (withId && params instanceof IdentifableRequestParameters) {
+        rep.setId(((IdentifableRequestParameters) params).getId());
       }
 
       rep.update();

--- a/oscm-rest-api-common/src/main/java/org/oscm/rest/common/SampleTestDataUtility.java
+++ b/oscm-rest-api-common/src/main/java/org/oscm/rest/common/SampleTestDataUtility.java
@@ -138,9 +138,14 @@ public class SampleTestDataUtility {
     };
   }
 
+  public static IdentifiableAccountParameters createIdentifiableAccountParameters() {
+    IdentifiableAccountParameters parameters = new IdentifiableAccountParameters();
+    parameters.setId(TestContants.LONG_VALUE);
+    return parameters;
+  }
+
   public static AccountParameters createAccountParameters() {
     AccountParameters parameters = new AccountParameters();
-    parameters.setId(TestContants.LONG_VALUE);
     return parameters;
   }
 
@@ -277,6 +282,13 @@ public class SampleTestDataUtility {
 
   public static MarketplaceParameters createMarketplaceParameters() {
     MarketplaceParameters parameters = new MarketplaceParameters();
+    parameters.setVersion(TestContants.INTEGER_VALUE);
+    parameters.validateETag();
+    return parameters;
+  }
+
+  public static IdentifiableMarketplaceParameters createIdentifiableMarketplaceParameters() {
+    IdentifiableMarketplaceParameters parameters = new IdentifiableMarketplaceParameters();
     parameters.setId(TestContants.LONG_VALUE);
     parameters.setVersion(TestContants.INTEGER_VALUE);
     parameters.validateETag();
@@ -309,6 +321,11 @@ public class SampleTestDataUtility {
 
   public static OperationParameters createOperationParameters() {
     OperationParameters parameters = new OperationParameters();
+    return parameters;
+  }
+
+  public static IdentifiableOperationParameters createIdentifiableOperationParameters() {
+    IdentifiableOperationParameters parameters = new IdentifiableOperationParameters();
     parameters.setId(TestContants.LONG_VALUE);
     return parameters;
   }
@@ -323,6 +340,12 @@ public class SampleTestDataUtility {
 
   public static ServiceParameters createServiceParameters() {
     ServiceParameters parameters = new ServiceParameters();
+    parameters.setOrgKey(TestContants.LONG_VALUE);
+    return parameters;
+  }
+
+  public static IdentifiableServiceParameters createIdentifiableServiceParameters() {
+    IdentifiableServiceParameters parameters = new IdentifiableServiceParameters();
     parameters.setId(TestContants.LONG_VALUE);
     parameters.setOrgKey(TestContants.LONG_VALUE);
     return parameters;
@@ -372,6 +395,12 @@ public class SampleTestDataUtility {
 
   public static SubscriptionParameters createSubscriptionParameters() {
     SubscriptionParameters parameters = new SubscriptionParameters();
+    parameters.setLicKey(TestContants.LONG_VALUE);
+    return parameters;
+  }
+
+  public static IdentifiableSubscriptionParameters createIdentifiableSubscriptionParameters() {
+    IdentifiableSubscriptionParameters parameters = new IdentifiableSubscriptionParameters();
     parameters.setId(TestContants.LONG_VALUE);
     parameters.setLicKey(TestContants.LONG_VALUE);
     return parameters;

--- a/oscm-rest-api-common/src/main/java/org/oscm/rest/common/requestparameters/IdentifableRequestParameters.java
+++ b/oscm-rest-api-common/src/main/java/org/oscm/rest/common/requestparameters/IdentifableRequestParameters.java
@@ -1,0 +1,57 @@
+/**
+ * *****************************************************************************
+ *
+ * <p>Copyright FUJITSU LIMITED 2017
+ *
+ * <p>Creation Date: May 9, 2016
+ *
+ * <p>*****************************************************************************
+ */
+package org.oscm.rest.common.requestparameters;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import org.oscm.rest.common.CommonParams;
+import org.oscm.rest.common.WebException;
+
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.WebApplicationException;
+
+/**
+ * Base class for BeanParams
+ *
+ * @author miethaner
+ */
+public class IdentifableRequestParameters extends RequestParameters {
+
+  @Parameter(description = "ID of a single resource", required = true)
+  @PathParam(CommonParams.PARAM_ID)
+  private Long id;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  /**
+   * Validates the id string if it matches basic UUID format. Throws NotFoundException if not valid.
+   *
+   * @throws WebApplicationException
+   */
+  public void validateId() throws WebApplicationException {
+
+    if (id == null) {
+      throw WebException.notFound().message(CommonParams.ERROR_INVALID_ID).build();
+    }
+  }
+
+  public long convertIdToKey() {
+    if (getId() == null) {
+      return 0L;
+    }
+    return getId().longValue();
+  }
+}

--- a/oscm-rest-api-common/src/main/java/org/oscm/rest/common/requestparameters/IdentifiableAccountParameters.java
+++ b/oscm-rest-api-common/src/main/java/org/oscm/rest/common/requestparameters/IdentifiableAccountParameters.java
@@ -10,10 +10,11 @@
 package org.oscm.rest.common.requestparameters;
 
 import io.swagger.v3.oas.annotations.Parameter;
+
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 
-public class AccountParameters extends RequestParameters {
+public class IdentifiableAccountParameters extends IdentifableRequestParameters {
 
   @Parameter(description = "Marketplace ID")
   @QueryParam("marketplaceId")
@@ -44,4 +45,7 @@ public class AccountParameters extends RequestParameters {
   public void setOrgId(String orgId) {
     this.orgId = orgId;
   }
+
+  @Override
+  public void validateId() throws WebApplicationException {}
 }

--- a/oscm-rest-api-common/src/main/java/org/oscm/rest/common/requestparameters/IdentifiableMarketplaceParameters.java
+++ b/oscm-rest-api-common/src/main/java/org/oscm/rest/common/requestparameters/IdentifiableMarketplaceParameters.java
@@ -1,0 +1,66 @@
+/**
+ * *****************************************************************************
+ *
+ * <p>Copyright FUJITSU LIMITED 2019
+ *
+ * <p>Creation Date: 10-04-2019
+ *
+ * <p>*****************************************************************************
+ */
+package org.oscm.rest.common.requestparameters;
+
+import org.oscm.internal.vo.VOService;
+import org.oscm.rest.common.MarketplaceListType;
+
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+
+public class IdentifiableMarketplaceParameters extends IdentifableRequestParameters {
+
+  @QueryParam("listType")
+  private MarketplaceListType listType = MarketplaceListType.OWNED;
+
+  @QueryParam("mId")
+  private String marketplaceId;
+
+  @QueryParam("sKey")
+  private Long serviceKey;
+
+  @Override
+  public void validateParameters() throws WebApplicationException {}
+
+  @Override
+  public void update() {}
+
+  public String getMarketplaceId() {
+    return marketplaceId;
+  }
+
+  public void setMarketplaceId(String marketplaceId) {
+    this.marketplaceId = marketplaceId;
+  }
+
+  public MarketplaceListType getListType() {
+    return listType;
+  }
+
+  public void setListType(MarketplaceListType listType) {
+    this.listType = listType;
+  }
+
+  public Long getServiceKey() {
+    return serviceKey;
+  }
+
+  public void setServiceKey(Long serviceKey) {
+    this.serviceKey = serviceKey;
+  }
+
+  public VOService getService() {
+    VOService svc = new VOService();
+    if (serviceKey != null) {
+      svc.setKey(serviceKey.longValue());
+    }
+    return svc;
+  }
+}

--- a/oscm-rest-api-common/src/main/java/org/oscm/rest/common/requestparameters/IdentifiableOperationParameters.java
+++ b/oscm-rest-api-common/src/main/java/org/oscm/rest/common/requestparameters/IdentifiableOperationParameters.java
@@ -1,0 +1,21 @@
+/**
+ * *****************************************************************************
+ *
+ * <p>Copyright FUJITSU LIMITED 2019
+ *
+ * <p>Creation Date: 10-04-2019
+ *
+ * <p>*****************************************************************************
+ */
+package org.oscm.rest.common.requestparameters;
+
+import javax.ws.rs.WebApplicationException;
+
+public class IdentifiableOperationParameters extends IdentifableRequestParameters {
+
+  @Override
+  public void validateParameters() throws WebApplicationException {}
+
+  @Override
+  public void update() {}
+}

--- a/oscm-rest-api-common/src/main/java/org/oscm/rest/common/requestparameters/IdentifiableServiceParameters.java
+++ b/oscm-rest-api-common/src/main/java/org/oscm/rest/common/requestparameters/IdentifiableServiceParameters.java
@@ -9,17 +9,14 @@
  */
 package org.oscm.rest.common.requestparameters;
 
-import io.swagger.v3.oas.annotations.Parameter;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 
-public class AccountParameters extends RequestParameters {
+public class IdentifiableServiceParameters extends IdentifableRequestParameters {
 
-  @Parameter(description = "Marketplace ID")
-  @QueryParam("marketplaceId")
-  private String marketplaceId;
+  @QueryParam("orgKey")
+  private Long orgKey;
 
-  @Parameter(description = "Organization ID")
   @QueryParam("orgId")
   private String orgId;
 
@@ -27,14 +24,17 @@ public class AccountParameters extends RequestParameters {
   public void validateParameters() throws WebApplicationException {}
 
   @Override
+  public void validateETag() throws WebApplicationException {}
+
+  @Override
   public void update() {}
 
-  public String getMarketplaceId() {
-    return marketplaceId;
+  public Long getOrgKey() {
+    return orgKey;
   }
 
-  public void setMarketplaceId(String marketplaceId) {
-    this.marketplaceId = marketplaceId;
+  public void setOrgKey(Long orgKey) {
+    this.orgKey = orgKey;
   }
 
   public String getOrgId() {
@@ -43,5 +43,12 @@ public class AccountParameters extends RequestParameters {
 
   public void setOrgId(String orgId) {
     this.orgId = orgId;
+  }
+
+  public int eTagToVersion() {
+    if (getETag() == null) {
+      return 0;
+    }
+    return getETag().intValue();
   }
 }

--- a/oscm-rest-api-common/src/main/java/org/oscm/rest/common/requestparameters/IdentifiableSubscriptionParameters.java
+++ b/oscm-rest-api-common/src/main/java/org/oscm/rest/common/requestparameters/IdentifiableSubscriptionParameters.java
@@ -10,26 +10,25 @@
 package org.oscm.rest.common.requestparameters;
 
 import io.swagger.v3.oas.annotations.Parameter;
+
+import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
-import org.oscm.rest.common.CommonParams;
-import org.oscm.rest.common.WebException;
 
-public class EventParameters extends RequestParameters {
+public class IdentifiableSubscriptionParameters extends IdentifableRequestParameters {
 
   @QueryParam("userId")
   private String userId;
 
-  @QueryParam("mId")
-  @Parameter(description = "Marketplace ID.")
-  private String marketplaceId;
-
-  @QueryParam("pattern")
-  @Parameter(description = "The pattern.")
-  private String pattern;
+  @Parameter(description = "Subscription's usage license key", required = true)
+  @PathParam("licKey")
+  private Long licKey;
 
   @Override
   public void validateParameters() throws WebApplicationException {}
+
+  @Override
+  public void validateETag() throws WebApplicationException {}
 
   @Override
   public void update() {}
@@ -42,19 +41,11 @@ public class EventParameters extends RequestParameters {
     this.userId = userId;
   }
 
-  public String getMarketplaceId() {
-    return marketplaceId;
+  public Long getLicKey() {
+    return licKey;
   }
 
-  public void setMarketplaceId(String marketplaceId) {
-    this.marketplaceId = marketplaceId;
-  }
-
-  public String getPattern() {
-    return pattern;
-  }
-
-  public void setPattern(String pattern) {
-    this.pattern = pattern;
+  public void setLicKey(Long licKey) {
+    this.licKey = licKey;
   }
 }

--- a/oscm-rest-api-common/src/main/java/org/oscm/rest/common/requestparameters/IdentifiableUserParameters.java
+++ b/oscm-rest-api-common/src/main/java/org/oscm/rest/common/requestparameters/IdentifiableUserParameters.java
@@ -10,24 +10,40 @@
 package org.oscm.rest.common.requestparameters;
 
 import io.swagger.v3.oas.annotations.Parameter;
+
+import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 
-public class AccountParameters extends RequestParameters {
+public class IdentifiableUserParameters extends IdentifableRequestParameters {
 
+  @PathParam("userId")
+  @Parameter(description = "User ID")
+  private String userId;
+
+  @QueryParam("mId")
   @Parameter(description = "Marketplace ID")
-  @QueryParam("marketplaceId")
   private String marketplaceId;
 
-  @Parameter(description = "Organization ID")
-  @QueryParam("orgId")
-  private String orgId;
+  @QueryParam("pattern")
+  @Parameter(description = "Pattern")
+  private String pattern;
+
+  private boolean isUserIdRequired;
 
   @Override
   public void validateParameters() throws WebApplicationException {}
 
   @Override
   public void update() {}
+
+  public String getUserId() {
+    return userId;
+  }
+
+  public void setUserId(String userId) {
+    this.userId = userId;
+  }
 
   public String getMarketplaceId() {
     return marketplaceId;
@@ -37,11 +53,19 @@ public class AccountParameters extends RequestParameters {
     this.marketplaceId = marketplaceId;
   }
 
-  public String getOrgId() {
-    return orgId;
+  public String getPattern() {
+    return pattern;
   }
 
-  public void setOrgId(String orgId) {
-    this.orgId = orgId;
+  public void setPattern(String pattern) {
+    this.pattern = pattern;
+  }
+
+  public void setUserIdRequired(boolean userIdRequired) {
+    this.isUserIdRequired = userIdRequired;
+  }
+
+  public boolean getUserIdRequired() {
+    return isUserIdRequired;
   }
 }

--- a/oscm-rest-api-common/src/main/java/org/oscm/rest/common/requestparameters/RequestParameters.java
+++ b/oscm-rest-api-common/src/main/java/org/oscm/rest/common/requestparameters/RequestParameters.java
@@ -10,11 +10,12 @@
 package org.oscm.rest.common.requestparameters;
 
 import io.swagger.v3.oas.annotations.Parameter;
+import org.oscm.rest.common.CommonParams;
+import org.oscm.rest.common.WebException;
+
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.WebApplicationException;
-import org.oscm.rest.common.CommonParams;
-import org.oscm.rest.common.WebException;
 
 /**
  * Base class for BeanParams
@@ -24,10 +25,6 @@ import org.oscm.rest.common.WebException;
 public class RequestParameters {
 
   private int version;
-
-  @Parameter(description = "ID of a single resource", required = true)
-  @PathParam(CommonParams.PARAM_ID)
-  private Long id;
 
   @Parameter(description = "Endpoint's version", required = true)
   @PathParam(CommonParams.PARAM_VERSION)
@@ -49,14 +46,6 @@ public class RequestParameters {
     this.version = version;
   }
 
-  public Long getId() {
-    return id;
-  }
-
-  public void setId(Long id) {
-    this.id = id;
-  }
-
   public String getEndpointVersion() {
     return endpointVersion;
   }
@@ -75,18 +64,6 @@ public class RequestParameters {
 
   public void setEtag(Long etag) {
     this.etag = etag;
-  }
-
-  /**
-   * Validates the id string if it matches basic UUID format. Throws NotFoundException if not valid.
-   *
-   * @throws WebApplicationException
-   */
-  public void validateId() throws WebApplicationException {
-
-    if (id == null) {
-      throw WebException.notFound().message(CommonParams.ERROR_INVALID_ID).build();
-    }
   }
 
   /**
@@ -131,13 +108,6 @@ public class RequestParameters {
 
   public void setNoneMatch(String noneMatch) {
     this.noneMatch = noneMatch;
-  }
-
-  public long convertIdToKey() {
-    if (getId() == null) {
-      return 0L;
-    }
-    return getId().longValue();
   }
 
   public int convertETagToVersion() {

--- a/oscm-rest-api-common/src/main/java/org/oscm/rest/common/requestparameters/UserParameters.java
+++ b/oscm-rest-api-common/src/main/java/org/oscm/rest/common/requestparameters/UserParameters.java
@@ -17,6 +17,7 @@ import org.oscm.rest.common.WebException;
 
 public class UserParameters extends RequestParameters {
 
+  //FIXME: This should be in fact a @PathParam
   @QueryParam("userId")
   @Parameter(description = "User ID")
   private String userId;
@@ -59,13 +60,6 @@ public class UserParameters extends RequestParameters {
 
   public void setPattern(String pattern) {
     this.pattern = pattern;
-  }
-
-  @Override
-  public void validateId() throws WebApplicationException {
-    if (isUserIdRequired && userId == null) {
-      throw WebException.notFound().message(CommonParams.ERROR_INVALID_ID).build();
-    }
   }
 
   public void setUserIdRequired(boolean userIdRequired) {

--- a/oscm-rest-api-common/src/test/java/org/oscm/rest/common/RequestParametersTest.java
+++ b/oscm-rest-api-common/src/test/java/org/oscm/rest/common/RequestParametersTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 import org.junit.jupiter.api.Test;
+import org.oscm.rest.common.requestparameters.IdentifableRequestParameters;
 import org.oscm.rest.common.requestparameters.RequestParameters;
 
 /**
@@ -25,7 +26,7 @@ import org.oscm.rest.common.requestparameters.RequestParameters;
  */
 public class RequestParametersTest {
 
-  private class TestParameters extends RequestParameters {
+  private class TestParameters extends IdentifableRequestParameters {
 
     @Override
     public void validateParameters() throws WebApplicationException {}
@@ -37,7 +38,7 @@ public class RequestParametersTest {
   @Test
   public void testIdValidation() throws Exception {
 
-    RequestParameters params = new TestParameters();
+    IdentifableRequestParameters params = new TestParameters();
 
     params.setId(1L);
 
@@ -127,7 +128,7 @@ public class RequestParametersTest {
 
   @Test
   public void shouldConvertIdToKey_givenNullId() {
-    RequestParameters parameters = new TestParameters();
+    IdentifableRequestParameters parameters = new TestParameters();
 
     Long result = parameters.convertIdToKey();
 
@@ -136,7 +137,7 @@ public class RequestParametersTest {
 
   @Test
   public void shouldConvertIdToKey_givenNoNNullId() {
-    RequestParameters parameters = new TestParameters();
+    IdentifableRequestParameters parameters = new TestParameters();
     parameters.setId(12345L);
 
     Long result = parameters.convertIdToKey();

--- a/oscm-rest-api-common/src/test/java/org/oscm/rest/common/RestResourceTest.java
+++ b/oscm-rest-api-common/src/test/java/org/oscm/rest/common/RestResourceTest.java
@@ -12,6 +12,7 @@ package org.oscm.rest.common;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.oscm.rest.common.representation.Representation;
+import org.oscm.rest.common.requestparameters.IdentifableRequestParameters;
 import org.oscm.rest.common.requestparameters.RequestParameters;
 
 import javax.ws.rs.WebApplicationException;
@@ -38,7 +39,7 @@ public class RestResourceTest extends RestResource {
     public void validateContent() throws WebApplicationException {}
   }
 
-  private class MockRequestParameters extends RequestParameters {
+  private class MockRequestParameters extends IdentifableRequestParameters {
 
     @Override
     public void validateParameters() throws WebApplicationException {}

--- a/oscm-rest-api-common/src/test/java/org/oscm/rest/common/requestparameters/AccountParametersTest.java
+++ b/oscm-rest-api-common/src/test/java/org/oscm/rest/common/requestparameters/AccountParametersTest.java
@@ -10,7 +10,7 @@ public class AccountParametersTest {
 
         @Test
         public void shouldCreate() {
-             AccountParameters parameters = new AccountParameters();
+             IdentifiableAccountParameters parameters = new IdentifiableAccountParameters();
              parameters.setOrgId(TestContants.STRING_VALUE);
              parameters.setMarketplaceId(TestContants.STRING_VALUE);
 
@@ -18,8 +18,8 @@ public class AccountParametersTest {
              parameters.validateParameters();
              parameters.update();
 
-             assertThat(parameters).extracting(AccountParameters::getOrgId).isEqualTo(TestContants.STRING_VALUE);
-             assertThat(parameters).extracting(AccountParameters::getMarketplaceId).isEqualTo(TestContants.STRING_VALUE);
+             assertThat(parameters).extracting(IdentifiableAccountParameters::getOrgId).isEqualTo(TestContants.STRING_VALUE);
+             assertThat(parameters).extracting(IdentifiableAccountParameters::getMarketplaceId).isEqualTo(TestContants.STRING_VALUE);
         }
 
 }

--- a/oscm-rest-api-common/src/test/java/org/oscm/rest/common/requestparameters/EventParametersTest.java
+++ b/oscm-rest-api-common/src/test/java/org/oscm/rest/common/requestparameters/EventParametersTest.java
@@ -16,7 +16,6 @@ public class EventParametersTest {
                 parameters.setUserId(TestContants.STRING_VALUE);
 
                 parameters.validateParameters();
-                parameters.validateId();
                 parameters.update();
 
                 assertThat(parameters).extracting(EventParameters::getMarketplaceId).isEqualTo(TestContants.STRING_VALUE);

--- a/oscm-rest-api-common/src/test/java/org/oscm/rest/common/requestparameters/UserParametersTest.java
+++ b/oscm-rest-api-common/src/test/java/org/oscm/rest/common/requestparameters/UserParametersTest.java
@@ -17,7 +17,6 @@ public class UserParametersTest {
 
              parameters.update();
              parameters.validateParameters();
-             parameters.validateId();
 
              assertThat(parameters).extracting(UserParameters::getUserId).isEqualTo(TestContants.STRING_VALUE);
              assertThat(parameters).extracting(UserParameters::getMarketplaceId).isEqualTo(TestContants.STRING_VALUE);

--- a/oscm-rest-api-marketplace/src/main/java/org/oscm/rest/marketplace/EntryBackend.java
+++ b/oscm-rest-api-marketplace/src/main/java/org/oscm/rest/marketplace/EntryBackend.java
@@ -21,6 +21,7 @@ import org.oscm.internal.vo.VOCatalogEntry;
 import org.oscm.internal.vo.VOMarketplace;
 import org.oscm.rest.common.RestBackend;
 import org.oscm.rest.common.representation.EntryRepresentation;
+import org.oscm.rest.common.requestparameters.IdentifiableMarketplaceParameters;
 import org.oscm.rest.common.requestparameters.MarketplaceParameters;
 
 @Stateless
@@ -28,7 +29,7 @@ public class EntryBackend {
 
   @EJB MarketplaceService ms;
 
-  public RestBackend.Put<EntryRepresentation, MarketplaceParameters> put()
+  public RestBackend.Put<EntryRepresentation, IdentifiableMarketplaceParameters> put()
       throws ObjectNotFoundException, ValidationException, NonUniqueBusinessKeyException,
           OperationNotPermittedException {
     return (content, params) -> {

--- a/oscm-rest-api-marketplace/src/main/java/org/oscm/rest/marketplace/EntryResource.java
+++ b/oscm-rest-api-marketplace/src/main/java/org/oscm/rest/marketplace/EntryResource.java
@@ -32,6 +32,7 @@ import org.oscm.rest.common.RestResource;
 import org.oscm.rest.common.Since;
 import org.oscm.rest.common.errorhandling.RestErrorResponseFactory;
 import org.oscm.rest.common.representation.EntryRepresentation;
+import org.oscm.rest.common.requestparameters.IdentifiableMarketplaceParameters;
 import org.oscm.rest.common.requestparameters.MarketplaceParameters;
 
 @Path(CommonParams.PATH_VERSION + "/marketplaces" + CommonParams.PATH_ID + "/entries/{sKey}")
@@ -71,7 +72,7 @@ public class EntryResource extends RestResource {
   public Response updateCatalogEntry(
       @Context UriInfo uriInfo,
       EntryRepresentation content,
-      @BeanParam MarketplaceParameters params)
+      @BeanParam IdentifiableMarketplaceParameters params)
       throws Exception {
     try {
       return put(uriInfo, eb.put(), content, params);

--- a/oscm-rest-api-marketplace/src/main/java/org/oscm/rest/marketplace/MarketplaceBackend.java
+++ b/oscm-rest-api-marketplace/src/main/java/org/oscm/rest/marketplace/MarketplaceBackend.java
@@ -20,6 +20,7 @@ import org.oscm.internal.vo.VOMarketplace;
 import org.oscm.rest.common.RestBackend;
 import org.oscm.rest.common.representation.MarketplaceRepresentation;
 import org.oscm.rest.common.representation.RepresentationCollection;
+import org.oscm.rest.common.requestparameters.IdentifiableMarketplaceParameters;
 import org.oscm.rest.common.requestparameters.MarketplaceParameters;
 
 @Stateless
@@ -58,7 +59,7 @@ public class MarketplaceBackend {
     };
   }
 
-  public RestBackend.Put<MarketplaceRepresentation, MarketplaceParameters> put()
+  public RestBackend.Put<MarketplaceRepresentation, IdentifiableMarketplaceParameters> put()
       throws ObjectNotFoundException, OperationNotPermittedException, ConcurrentAccessException,
           ValidationException, UserRoleAssignmentException, IllegalArgumentException {
     return (content, params) -> {
@@ -70,7 +71,7 @@ public class MarketplaceBackend {
     };
   }
 
-  public RestBackend.Delete<MarketplaceParameters> delete()
+  public RestBackend.Delete<IdentifiableMarketplaceParameters> delete()
       throws IllegalArgumentException, ObjectNotFoundException, NonUniqueBusinessKeyException {
     return params -> {
       String mId = ms.getMarketplaceIdForKey(params.getId());
@@ -79,7 +80,7 @@ public class MarketplaceBackend {
     };
   }
 
-  public RestBackend.Get<MarketplaceRepresentation, MarketplaceParameters> get()
+  public RestBackend.Get<MarketplaceRepresentation, IdentifiableMarketplaceParameters> get()
       throws ObjectNotFoundException {
     return params -> {
       String mId = ms.getMarketplaceIdForKey(params.getId());

--- a/oscm-rest-api-marketplace/src/main/java/org/oscm/rest/marketplace/MarketplaceResource.java
+++ b/oscm-rest-api-marketplace/src/main/java/org/oscm/rest/marketplace/MarketplaceResource.java
@@ -30,6 +30,7 @@ import org.oscm.rest.common.RestResource;
 import org.oscm.rest.common.Since;
 import org.oscm.rest.common.errorhandling.RestErrorResponseFactory;
 import org.oscm.rest.common.representation.MarketplaceRepresentation;
+import org.oscm.rest.common.requestparameters.IdentifiableMarketplaceParameters;
 import org.oscm.rest.common.requestparameters.MarketplaceParameters;
 
 @Path(CommonParams.PATH_VERSION + "/marketplaces")
@@ -77,7 +78,7 @@ public class MarketplaceResource extends RestResource {
             description = "A single marketplace",
             content = @Content(schema = @Schema(implementation = MarketplaceRepresentation.class)))
       })
-  public Response getMarketplace(@Context UriInfo uriInfo, @BeanParam MarketplaceParameters params)
+  public Response getMarketplace(@Context UriInfo uriInfo, @BeanParam IdentifiableMarketplaceParameters params)
       throws Exception {
     try {
       return get(uriInfo, mb.get(), params, true);
@@ -154,7 +155,7 @@ public class MarketplaceResource extends RestResource {
   public Response updateMarketplace(
       @Context UriInfo uriInfo,
       MarketplaceRepresentation content,
-      @BeanParam MarketplaceParameters params) {
+      @BeanParam IdentifiableMarketplaceParameters params) {
     try {
       return put(uriInfo, mb.put(), content, params);
     } catch (Exception e) {
@@ -173,7 +174,7 @@ public class MarketplaceResource extends RestResource {
         @ApiResponse(responseCode = "204", description = "Marketplace deleted successfully")
       })
   public Response deleteMarketplace(
-      @Context UriInfo uriInfo, @BeanParam MarketplaceParameters params) {
+      @Context UriInfo uriInfo, @BeanParam IdentifiableMarketplaceParameters params) {
     try {
       return delete(uriInfo, mb.delete(), params);
     } catch (Exception e) {

--- a/oscm-rest-api-marketplace/src/test/java/org/oscm/rest/marketplace/EntryBackendTest.java
+++ b/oscm-rest-api-marketplace/src/test/java/org/oscm/rest/marketplace/EntryBackendTest.java
@@ -19,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.oscm.internal.intf.MarketplaceService;
 import org.oscm.internal.vo.VOServiceDetails;
 import org.oscm.rest.common.SampleTestDataUtility;
+import org.oscm.rest.common.requestparameters.IdentifiableMarketplaceParameters;
 import org.oscm.rest.common.requestparameters.MarketplaceParameters;
 import org.oscm.rest.common.representation.EntryRepresentation;
 
@@ -37,7 +38,7 @@ public class EntryBackendTest {
   private EntryResource resource;
 
   private UriInfo uriInfo;
-  private MarketplaceParameters parameters;
+  private IdentifiableMarketplaceParameters parameters;
   private EntryRepresentation representation;
   private VOServiceDetails vo;
 
@@ -46,7 +47,7 @@ public class EntryBackendTest {
     resource = new EntryResource();
     resource.setEb(backend);
     uriInfo = SampleTestDataUtility.createUriInfo();
-    parameters = SampleTestDataUtility.createMarketplaceParameters();
+    parameters = SampleTestDataUtility.createIdentifiableMarketplaceParameters();
     representation = SampleTestDataUtility.createEntryRepresentation();
     vo = SampleTestDataUtility.createVOServiceDetails();
   }

--- a/oscm-rest-api-marketplace/src/test/java/org/oscm/rest/marketplace/EntryResourceTest.java
+++ b/oscm-rest-api-marketplace/src/test/java/org/oscm/rest/marketplace/EntryResourceTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.oscm.rest.common.SampleTestDataUtility;
+import org.oscm.rest.common.requestparameters.IdentifiableMarketplaceParameters;
 import org.oscm.rest.common.requestparameters.MarketplaceParameters;
 import org.oscm.rest.common.representation.EntryRepresentation;
 
@@ -30,7 +31,7 @@ class EntryResourceTest {
     private EntryResource entryResource;
 
     private Response response;
-    private MarketplaceParameters marketplaceParameters;
+    private IdentifiableMarketplaceParameters marketplaceParameters;
     private UriInfo uriInfo;
     private EntryRepresentation entryRepresentation;
 
@@ -38,7 +39,7 @@ class EntryResourceTest {
     public void setUp() {
         entryRepresentation = SampleTestDataUtility.createEntryRepresentation();
         uriInfo = SampleTestDataUtility.createUriInfo();
-        marketplaceParameters = SampleTestDataUtility.createMarketplaceParameters();
+        marketplaceParameters = SampleTestDataUtility.createIdentifiableMarketplaceParameters();
     }
 
     @AfterEach

--- a/oscm-rest-api-marketplace/src/test/java/org/oscm/rest/marketplace/MarketplaceBackendTest.java
+++ b/oscm-rest-api-marketplace/src/test/java/org/oscm/rest/marketplace/MarketplaceBackendTest.java
@@ -24,6 +24,7 @@ import org.oscm.internal.vo.VOMarketplace;
 import org.oscm.rest.common.MarketplaceListType;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.SampleTestDataUtility;
+import org.oscm.rest.common.requestparameters.IdentifiableMarketplaceParameters;
 import org.oscm.rest.common.requestparameters.MarketplaceParameters;
 import org.oscm.rest.common.representation.MarketplaceRepresentation;
 
@@ -44,6 +45,7 @@ public class MarketplaceBackendTest {
   private UriInfo uriInfo;
   private MarketplaceRepresentation representation;
   private MarketplaceParameters parameters;
+  private IdentifiableMarketplaceParameters indentifiableParameters;
   private VOMarketplace vo;
 
   @BeforeEach
@@ -53,6 +55,7 @@ public class MarketplaceBackendTest {
     uriInfo = SampleTestDataUtility.createUriInfo();
     representation = SampleTestDataUtility.createMarketplaceRepresentation();
     parameters = SampleTestDataUtility.createMarketplaceParameters();
+    indentifiableParameters = SampleTestDataUtility.createIdentifiableMarketplaceParameters();
     vo = SampleTestDataUtility.createVOMarketplace();
   }
 
@@ -88,7 +91,7 @@ public class MarketplaceBackendTest {
     when(service.getMarketplaceIdForKey(any())).thenReturn(representation.getMarketplaceId());
     when(service.getMarketplaceById(any())).thenReturn(vo);
 
-    Response response = resource.getMarketplace(uriInfo, parameters);
+    Response response = resource.getMarketplace(uriInfo, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -115,7 +118,7 @@ public class MarketplaceBackendTest {
   public void shouldUpdateMarketplace() {
     when(service.updateMarketplace(any())).thenReturn(vo);
 
-    Response response = resource.updateMarketplace(uriInfo, representation, parameters);
+    Response response = resource.updateMarketplace(uriInfo, representation, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -128,7 +131,7 @@ public class MarketplaceBackendTest {
   public void shouldDeleteMarketplace() {
     doNothing().when(service).deleteMarketplace(any());
 
-    Response response = resource.deleteMarketplace(uriInfo, parameters);
+    Response response = resource.deleteMarketplace(uriInfo, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)

--- a/oscm-rest-api-marketplace/src/test/java/org/oscm/rest/marketplace/MarketplaceResourceTest.java
+++ b/oscm-rest-api-marketplace/src/test/java/org/oscm/rest/marketplace/MarketplaceResourceTest.java
@@ -28,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.oscm.rest.common.SampleTestDataUtility;
 import org.oscm.rest.common.representation.MarketplaceRepresentation;
 import org.oscm.rest.common.representation.RepresentationCollection;
+import org.oscm.rest.common.requestparameters.IdentifiableMarketplaceParameters;
 import org.oscm.rest.common.requestparameters.MarketplaceParameters;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,12 +42,14 @@ class MarketplaceResourceTest {
   private MarketplaceRepresentation marketplaceRepresentation;
   private UriInfo uriInfo;
   private MarketplaceParameters marketplaceParameters;
+  private IdentifiableMarketplaceParameters identifiableMarketplaceParameters;
 
   @BeforeEach
   public void setUp() {
     marketplaceRepresentation = SampleTestDataUtility.createMarketplaceRepresentation();
     uriInfo = SampleTestDataUtility.createUriInfo();
     marketplaceParameters = SampleTestDataUtility.createMarketplaceParameters();
+    identifiableMarketplaceParameters = SampleTestDataUtility.createIdentifiableMarketplaceParameters();
   }
 
   @AfterEach
@@ -107,7 +110,7 @@ class MarketplaceResourceTest {
     when(marketplaceBackend.get()).thenReturn(params -> marketplaceRepresentation);
 
     try {
-      response = marketplaceResource.getMarketplace(uriInfo, marketplaceParameters);
+      response = marketplaceResource.getMarketplace(uriInfo, identifiableMarketplaceParameters);
     } catch (Exception e) {
       fail(e);
     }
@@ -128,7 +131,7 @@ class MarketplaceResourceTest {
     try {
       response =
           marketplaceResource.updateMarketplace(
-              uriInfo, marketplaceRepresentation, marketplaceParameters);
+              uriInfo, marketplaceRepresentation, identifiableMarketplaceParameters);
     } catch (Exception e) {
       fail(e);
     }
@@ -146,7 +149,7 @@ class MarketplaceResourceTest {
     when(marketplaceBackend.delete()).thenReturn(params -> true);
 
     try {
-      response = marketplaceResource.deleteMarketplace(uriInfo, marketplaceParameters);
+      response = marketplaceResource.deleteMarketplace(uriInfo, identifiableMarketplaceParameters);
     } catch (Exception e) {
       fail(e);
     }

--- a/oscm-rest-api-operation/src/main/java/org/oscm/rest/operation/SettingsBackend.java
+++ b/oscm-rest-api-operation/src/main/java/org/oscm/rest/operation/SettingsBackend.java
@@ -13,6 +13,7 @@ import org.oscm.internal.intf.ConfigurationService;
 import org.oscm.internal.intf.OperatorService;
 import org.oscm.internal.vo.VOConfigurationSetting;
 import org.oscm.rest.common.RestBackend;
+import org.oscm.rest.common.requestparameters.IdentifiableOperationParameters;
 import org.oscm.rest.common.requestparameters.OperationParameters;
 import org.oscm.rest.common.representation.SettingRepresentation;
 
@@ -27,7 +28,7 @@ public class SettingsBackend {
 
   @EJB ConfigurationService cs;
 
-  public RestBackend.Delete<OperationParameters> delete() throws Exception {
+  public RestBackend.Delete<IdentifiableOperationParameters> delete() throws Exception {
     return params -> {
       os.deleteConfigurationSetting(params.getId());
       return true;
@@ -43,14 +44,14 @@ public class SettingsBackend {
     };
   }
 
-  public RestBackend.Put<SettingRepresentation, OperationParameters> put() throws Exception {
+  public RestBackend.Put<SettingRepresentation, IdentifiableOperationParameters> put() throws Exception {
     return (content, params) -> {
       os.saveConfigurationSetting(content.getVO());
       return true;
     };
   }
 
-  public RestBackend.Get<SettingRepresentation, OperationParameters> get() throws Exception {
+  public RestBackend.Get<SettingRepresentation, IdentifiableOperationParameters> get() throws Exception {
     return params -> {
       VOConfigurationSetting vo = os.getConfigurationSetting(params.getId());
       return new SettingRepresentation(vo);

--- a/oscm-rest-api-operation/src/main/java/org/oscm/rest/operation/SettingsResource.java
+++ b/oscm-rest-api-operation/src/main/java/org/oscm/rest/operation/SettingsResource.java
@@ -29,6 +29,7 @@ import org.oscm.rest.common.CommonParams;
 import org.oscm.rest.common.RestResource;
 import org.oscm.rest.common.Since;
 import org.oscm.rest.common.representation.SettingRepresentation;
+import org.oscm.rest.common.requestparameters.IdentifiableOperationParameters;
 import org.oscm.rest.common.requestparameters.OperationParameters;
 
 @Path(CommonParams.PATH_VERSION + "/settings")
@@ -72,7 +73,7 @@ public class SettingsResource extends RestResource {
             description = "A single setting",
             content = @Content(schema = @Schema(implementation = SettingRepresentation.class)))
       })
-  public Response getSetting(@Context UriInfo uriInfo, @BeanParam OperationParameters params)
+  public Response getSetting(@Context UriInfo uriInfo, @BeanParam IdentifiableOperationParameters params)
       throws Exception {
     return get(uriInfo, sb.get(), params, true);
   }
@@ -133,7 +134,7 @@ public class SettingsResource extends RestResource {
   public Response updateSetting(
       @Context UriInfo uriInfo,
       SettingRepresentation content,
-      @BeanParam OperationParameters params)
+      @BeanParam IdentifiableOperationParameters params)
       throws Exception {
     return put(uriInfo, sb.put(), content, params);
   }
@@ -148,7 +149,7 @@ public class SettingsResource extends RestResource {
       responses = {
         @ApiResponse(responseCode = "204", description = "Setting deleted successfully")
       })
-  public Response deleteSetting(@Context UriInfo uriInfo, @BeanParam OperationParameters params)
+  public Response deleteSetting(@Context UriInfo uriInfo, @BeanParam IdentifiableOperationParameters params)
       throws Exception {
     return delete(uriInfo, sb.delete(), params);
   }

--- a/oscm-rest-api-operation/src/test/java/org/oscm/rest/operation/SettingsBackendTest.java
+++ b/oscm-rest-api-operation/src/test/java/org/oscm/rest/operation/SettingsBackendTest.java
@@ -22,6 +22,7 @@ import org.oscm.internal.intf.OperatorService;
 import org.oscm.internal.vo.VOConfigurationSetting;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.SampleTestDataUtility;
+import org.oscm.rest.common.requestparameters.IdentifiableOperationParameters;
 import org.oscm.rest.common.requestparameters.OperationParameters;
 import org.oscm.rest.common.representation.SettingRepresentation;
 
@@ -43,6 +44,7 @@ public class SettingsBackendTest {
 
   private UriInfo uriInfo;
   private OperationParameters parameters;
+  private IdentifiableOperationParameters indentifiableParameters;
   private SettingRepresentation representation;
   private VOConfigurationSetting vo;
 
@@ -53,6 +55,7 @@ public class SettingsBackendTest {
 
     uriInfo = SampleTestDataUtility.createUriInfo();
     parameters = SampleTestDataUtility.createOperationParameters();
+    indentifiableParameters = SampleTestDataUtility.createIdentifiableOperationParameters();
     representation = SampleTestDataUtility.createSettingRepresentation();
     vo = SampleTestDataUtility.createVOConfigurationSetting();
   }
@@ -82,7 +85,7 @@ public class SettingsBackendTest {
   public void shouldGetSettingById() {
     when(operatorService.getConfigurationSetting(any())).thenReturn(vo);
 
-    Response response = resource.getSetting(uriInfo, parameters);
+    Response response = resource.getSetting(uriInfo, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -110,7 +113,7 @@ public class SettingsBackendTest {
   public void shouldUpdateSetting() {
     doNothing().when(operatorService).saveConfigurationSetting(any());
 
-    Response response = resource.updateSetting(uriInfo, representation, parameters);
+    Response response = resource.updateSetting(uriInfo, representation, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -123,7 +126,7 @@ public class SettingsBackendTest {
   public void shouldDeleteSetting() {
     doNothing().when(operatorService).deleteConfigurationSetting(any());
 
-    Response response = resource.deleteSetting(uriInfo, parameters);
+    Response response = resource.deleteSetting(uriInfo, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)

--- a/oscm-rest-api-operation/src/test/java/org/oscm/rest/operation/SettingsResourceTest.java
+++ b/oscm-rest-api-operation/src/test/java/org/oscm/rest/operation/SettingsResourceTest.java
@@ -20,6 +20,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.SampleTestDataUtility;
+import org.oscm.rest.common.requestparameters.IdentifiableOperationParameters;
 import org.oscm.rest.common.requestparameters.OperationParameters;
 import org.oscm.rest.common.representation.SettingRepresentation;
 
@@ -41,12 +42,14 @@ class SettingsResourceTest {
   private SettingRepresentation settingRepresentation;
   private UriInfo uriInfo;
   private OperationParameters operationParameters;
+  private IdentifiableOperationParameters identifiableOperationParameters;
 
   @BeforeEach
   public void setUp() {
     settingRepresentation = SampleTestDataUtility.createSettingRepresentation();
     uriInfo = SampleTestDataUtility.createUriInfo();
     operationParameters = SampleTestDataUtility.createOperationParameters();
+    identifiableOperationParameters = SampleTestDataUtility.createIdentifiableOperationParameters();
   }
 
   @AfterEach
@@ -114,7 +117,7 @@ class SettingsResourceTest {
     }
 
     try {
-      response = settingsResource.getSetting(uriInfo, operationParameters);
+      response = settingsResource.getSetting(uriInfo, identifiableOperationParameters);
     } catch (Exception e) {
       fail(e);
     }
@@ -137,7 +140,7 @@ class SettingsResourceTest {
 
     try {
       response =
-          settingsResource.updateSetting(uriInfo, settingRepresentation, operationParameters);
+          settingsResource.updateSetting(uriInfo, settingRepresentation, identifiableOperationParameters);
     } catch (Exception e) {
       fail(e);
     }
@@ -158,7 +161,7 @@ class SettingsResourceTest {
     }
 
     try {
-      response = settingsResource.deleteSetting(uriInfo, operationParameters);
+      response = settingsResource.deleteSetting(uriInfo, identifiableOperationParameters);
     } catch (Exception e) {
       fail(e);
     }

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/CompatibleServiceResource.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/CompatibleServiceResource.java
@@ -33,6 +33,7 @@ import org.oscm.rest.common.RestResource;
 import org.oscm.rest.common.Since;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.representation.ServiceRepresentation;
+import org.oscm.rest.common.requestparameters.IdentifiableServiceParameters;
 import org.oscm.rest.common.requestparameters.ServiceParameters;
 
 @Path(CommonParams.PATH_VERSION + "/services" + CommonParams.PATH_ID + "/compatibleservices")
@@ -59,7 +60,7 @@ public class CompatibleServiceResource extends RestResource {
                     schema = @Schema(implementation = ServiceRepresentation.class)))
       })
   public Response getCompatibleServices(
-      @Context UriInfo uriInfo, @BeanParam ServiceParameters params) throws Exception {
+      @Context UriInfo uriInfo, @BeanParam IdentifiableServiceParameters params) throws Exception {
     return getCollection(uriInfo, sb.getCompatibles(), params);
   }
 
@@ -94,7 +95,7 @@ public class CompatibleServiceResource extends RestResource {
   public Response setCompatibleServices(
       @Context UriInfo uriInfo,
       RepresentationCollection<ServiceRepresentation> content,
-      @BeanParam ServiceParameters params)
+      @BeanParam IdentifiableServiceParameters params)
       throws Exception {
 
     params.setEtag(content.getETag());

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/PriceModelBackend.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/PriceModelBackend.java
@@ -16,6 +16,7 @@ import org.oscm.internal.vo.VOOrganization;
 import org.oscm.internal.vo.VOService;
 import org.oscm.internal.vo.VOServiceDetails;
 import org.oscm.rest.common.RestBackend;
+import org.oscm.rest.common.requestparameters.IdentifiableServiceParameters;
 import org.oscm.rest.common.requestparameters.ServiceParameters;
 import org.oscm.rest.common.representation.PriceModelRepresentation;
 
@@ -27,7 +28,7 @@ public class PriceModelBackend {
 
   @EJB ServiceProvisioningService sps;
 
-  public RestBackend.Put<PriceModelRepresentation, ServiceParameters> put() {
+  public RestBackend.Put<PriceModelRepresentation, IdentifiableServiceParameters> put() {
     return (content, params) -> {
       VOServiceDetails svc = new VOServiceDetails();
       svc.setKey(params.getId().longValue());
@@ -36,7 +37,7 @@ public class PriceModelBackend {
     };
   }
 
-  public RestBackend.Put<PriceModelRepresentation, ServiceParameters> putForCustomer() {
+  public RestBackend.Put<PriceModelRepresentation, IdentifiableServiceParameters> putForCustomer() {
     return (content, params) -> {
       VOServiceDetails svc = new VOServiceDetails();
       svc.setKey(params.getId().longValue());
@@ -47,7 +48,7 @@ public class PriceModelBackend {
     };
   }
 
-  public RestBackend.Get<PriceModelRepresentation, ServiceParameters> get() {
+  public RestBackend.Get<PriceModelRepresentation, IdentifiableServiceParameters> get() {
     return params -> {
       VOService vo = new VOService();
       vo.setKey(params.getId().longValue());
@@ -59,7 +60,7 @@ public class PriceModelBackend {
     };
   }
 
-  public RestBackend.Get<PriceModelRepresentation, ServiceParameters> getForCustomer() {
+  public RestBackend.Get<PriceModelRepresentation, IdentifiableServiceParameters> getForCustomer() {
     return params -> {
       VOService svc = new VOService();
       svc.setKey(params.getId().longValue());

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/PriceModelResource.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/PriceModelResource.java
@@ -32,6 +32,7 @@ import org.oscm.rest.common.CommonParams;
 import org.oscm.rest.common.RestResource;
 import org.oscm.rest.common.Since;
 import org.oscm.rest.common.representation.PriceModelRepresentation;
+import org.oscm.rest.common.requestparameters.IdentifiableServiceParameters;
 import org.oscm.rest.common.requestparameters.ServiceParameters;
 
 @Path(CommonParams.PATH_VERSION + "/services" + CommonParams.PATH_ID + "/pricemodel")
@@ -57,7 +58,7 @@ public class PriceModelResource extends RestResource {
                     mediaType = "application/json",
                     schema = @Schema(implementation = PriceModelRepresentation.class)))
       })
-  public Response get(@Context UriInfo uriInfo, @BeanParam ServiceParameters params)
+  public Response get(@Context UriInfo uriInfo, @BeanParam IdentifiableServiceParameters params)
       throws Exception {
     return get(uriInfo, pmb.get(), params, true);
   }
@@ -75,7 +76,7 @@ public class PriceModelResource extends RestResource {
             description = "Price model for the service",
             content = @Content(schema = @Schema(implementation = PriceModelRepresentation.class)))
       })
-  public Response getForCustomer(@Context UriInfo uriInfo, @BeanParam ServiceParameters params)
+  public Response getForCustomer(@Context UriInfo uriInfo, @BeanParam IdentifiableServiceParameters params)
       throws Exception {
     return get(uriInfo, pmb.getForCustomer(), params, true);
   }
@@ -109,7 +110,7 @@ public class PriceModelResource extends RestResource {
   public Response update(
       @Context UriInfo uriInfo,
       PriceModelRepresentation content,
-      @BeanParam ServiceParameters params)
+      @BeanParam IdentifiableServiceParameters params)
       throws Exception {
     return put(uriInfo, pmb.put(), content, params);
   }
@@ -144,7 +145,7 @@ public class PriceModelResource extends RestResource {
   public Response updateForCustomer(
       @Context UriInfo uriInfo,
       PriceModelRepresentation content,
-      @BeanParam ServiceParameters params)
+      @BeanParam IdentifiableServiceParameters params)
       throws Exception {
     return put(uriInfo, pmb.putForCustomer(), content, params);
   }

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/ServiceBackend.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/ServiceBackend.java
@@ -16,6 +16,7 @@ import org.oscm.internal.vo.VOService;
 import org.oscm.internal.vo.VOServiceDetails;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.RestBackend;
+import org.oscm.rest.common.requestparameters.IdentifiableServiceParameters;
 import org.oscm.rest.common.requestparameters.ServiceParameters;
 import org.oscm.rest.common.representation.ServiceDetailsRepresentation;
 import org.oscm.rest.common.representation.ServiceRepresentation;
@@ -30,7 +31,7 @@ public class ServiceBackend {
 
   @EJB ServiceProvisioningService sps;
 
-  public RestBackend.Delete<ServiceParameters> delete() {
+  public RestBackend.Delete<IdentifiableServiceParameters> delete() {
     return params -> {
       sps.deleteService(params.getId());
       return true;
@@ -46,7 +47,7 @@ public class ServiceBackend {
     };
   }
 
-  public RestBackend.Put<ServiceDetailsRepresentation, ServiceParameters> put() {
+  public RestBackend.Put<ServiceDetailsRepresentation, IdentifiableServiceParameters> put() {
     return (content, params) -> {
       // image will be handled in separate URL
       sps.updateService(content.getVO(), null);
@@ -54,7 +55,7 @@ public class ServiceBackend {
     };
   }
 
-  public RestBackend.Get<ServiceDetailsRepresentation, ServiceParameters> get() {
+  public RestBackend.Get<ServiceDetailsRepresentation, IdentifiableServiceParameters> get() {
     return params -> {
       VOService vo = new VOService();
       vo.setKey(params.getId().longValue());
@@ -74,7 +75,7 @@ public class ServiceBackend {
     };
   }
 
-  public RestBackend.GetCollection<ServiceRepresentation, ServiceParameters> getCompatibles() {
+  public RestBackend.GetCollection<ServiceRepresentation, IdentifiableServiceParameters> getCompatibles() {
     return params -> {
       VOService vo = new VOService();
       vo.setKey(params.getId().longValue());
@@ -84,7 +85,7 @@ public class ServiceBackend {
     };
   }
 
-  public RestBackend.Put<RepresentationCollection<ServiceRepresentation>, ServiceParameters>
+  public RestBackend.Put<RepresentationCollection<ServiceRepresentation>, IdentifiableServiceParameters>
       putCompatibles() {
     return (content, params) -> {
       VOService vo = new VOService();
@@ -96,7 +97,7 @@ public class ServiceBackend {
     };
   }
 
-  public RestBackend.Put<StatusRepresentation, ServiceParameters> putStatus() {
+  public RestBackend.Put<StatusRepresentation, IdentifiableServiceParameters> putStatus() {
     return (content, params) -> {
       VOService vo = new VOService();
       vo.setKey(params.getId().longValue());

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/ServiceResource.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/ServiceResource.java
@@ -31,6 +31,7 @@ import org.oscm.rest.common.Since;
 import org.oscm.rest.common.representation.ServiceDetailsRepresentation;
 import org.oscm.rest.common.representation.ServiceRepresentation;
 import org.oscm.rest.common.representation.StatusRepresentation;
+import org.oscm.rest.common.requestparameters.IdentifiableServiceParameters;
 import org.oscm.rest.common.requestparameters.ServiceParameters;
 
 @Path(CommonParams.PATH_VERSION + "/services")
@@ -74,7 +75,7 @@ public class ServiceResource extends RestResource {
             description = "A single service",
             content = @Content(schema = @Schema(implementation = ServiceRepresentation.class)))
       })
-  public Response getService(@Context UriInfo uriInfo, @BeanParam ServiceParameters params)
+  public Response getService(@Context UriInfo uriInfo, @BeanParam IdentifiableServiceParameters params)
       throws Exception {
     return get(uriInfo, sb.get(), params, true);
   }
@@ -143,7 +144,7 @@ public class ServiceResource extends RestResource {
   public Response updateService(
       @Context UriInfo uriInfo,
       ServiceDetailsRepresentation content,
-      @BeanParam ServiceParameters params)
+      @BeanParam IdentifiableServiceParameters params)
       throws Exception {
     return put(uriInfo, sb.put(), content, params);
   }
@@ -176,7 +177,7 @@ public class ServiceResource extends RestResource {
         @ApiResponse(responseCode = "204", description = "Service status updated successfully")
       })
   public Response setServiceState(
-      @Context UriInfo uriInfo, StatusRepresentation content, @BeanParam ServiceParameters params)
+      @Context UriInfo uriInfo, StatusRepresentation content, @BeanParam IdentifiableServiceParameters params)
       throws Exception {
     return put(uriInfo, sb.putStatus(), content, params);
   }
@@ -191,7 +192,7 @@ public class ServiceResource extends RestResource {
       responses = {
         @ApiResponse(responseCode = "204", description = "Service deleted successfully")
       })
-  public Response deleteService(@Context UriInfo uriInfo, @BeanParam ServiceParameters params)
+  public Response deleteService(@Context UriInfo uriInfo, @BeanParam IdentifiableServiceParameters params)
       throws Exception {
     return delete(uriInfo, sb.delete(), params);
   }

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TSSupplierBackend.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TSSupplierBackend.java
@@ -18,6 +18,7 @@ import org.oscm.internal.vo.VOOrganization;
 import org.oscm.internal.vo.VOTechnicalService;
 import org.oscm.rest.common.RestBackend;
 import org.oscm.rest.common.representation.OrganizationRepresentation;
+import org.oscm.rest.common.requestparameters.IdentifiableServiceParameters;
 import org.oscm.rest.common.requestparameters.ServiceParameters;
 
 @Stateless
@@ -25,7 +26,7 @@ public class TSSupplierBackend {
 
   @EJB AccountService as;
 
-  public RestBackend.GetCollection<OrganizationRepresentation, ServiceParameters> getCollection() {
+  public RestBackend.GetCollection<OrganizationRepresentation, IdentifiableServiceParameters> getCollection() {
     return params -> {
       VOTechnicalService vo = new VOTechnicalService();
       vo.setKey(params.getId().longValue());
@@ -34,7 +35,7 @@ public class TSSupplierBackend {
     };
   }
 
-  public RestBackend.Post<OrganizationRepresentation, ServiceParameters> post() {
+  public RestBackend.Post<OrganizationRepresentation, IdentifiableServiceParameters> post() {
     return (content, params) -> {
       VOTechnicalService vo = new VOTechnicalService();
       vo.setKey(params.getId().longValue());
@@ -43,7 +44,7 @@ public class TSSupplierBackend {
     };
   }
 
-  public RestBackend.Delete<ServiceParameters> delete() {
+  public RestBackend.Delete<IdentifiableServiceParameters> delete() {
     return params -> {
       VOTechnicalService vo = new VOTechnicalService();
       vo.setKey(params.getId().longValue());

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TSSupplierResource.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TSSupplierResource.java
@@ -29,6 +29,7 @@ import org.oscm.rest.common.CommonParams;
 import org.oscm.rest.common.RestResource;
 import org.oscm.rest.common.Since;
 import org.oscm.rest.common.representation.OrganizationRepresentation;
+import org.oscm.rest.common.requestparameters.IdentifiableServiceParameters;
 import org.oscm.rest.common.requestparameters.ServiceParameters;
 
 @Path(CommonParams.PATH_VERSION + "/technicalservices" + CommonParams.PATH_ID + "/suppliers")
@@ -54,7 +55,7 @@ public class TSSupplierResource extends RestResource {
                     mediaType = "application/json",
                     schema = @Schema(implementation = OrganizationRepresentation.class)))
       })
-  public Response getSuppliers(@Context UriInfo uriInfo, @BeanParam ServiceParameters params)
+  public Response getSuppliers(@Context UriInfo uriInfo, @BeanParam IdentifiableServiceParameters params)
       throws Exception {
     return getCollection(uriInfo, sb.getCollection(), params);
   }
@@ -90,7 +91,7 @@ public class TSSupplierResource extends RestResource {
   public Response addSupplier(
       @Context UriInfo uriInfo,
       OrganizationRepresentation content,
-      @BeanParam ServiceParameters params)
+      @BeanParam IdentifiableServiceParameters params)
       throws Exception {
     return post(uriInfo, sb.post(), content, params);
   }
@@ -107,7 +108,7 @@ public class TSSupplierResource extends RestResource {
             responseCode = "204",
             description = "Technical service supplier deleted successfully")
       })
-  public Response removeSupplier(@Context UriInfo uriInfo, @BeanParam ServiceParameters params)
+  public Response removeSupplier(@Context UriInfo uriInfo, @BeanParam IdentifiableServiceParameters params)
       throws Exception {
     return delete(uriInfo, sb.delete(), params);
   }

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TechnicalServiceBackend.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TechnicalServiceBackend.java
@@ -14,6 +14,7 @@ import org.oscm.internal.types.enumtypes.OrganizationRoleType;
 import org.oscm.internal.vo.VOTechnicalService;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.RestBackend;
+import org.oscm.rest.common.requestparameters.IdentifiableServiceParameters;
 import org.oscm.rest.common.requestparameters.ServiceParameters;
 import org.oscm.rest.common.representation.TechnicalServiceRepresentation;
 
@@ -39,7 +40,7 @@ public class TechnicalServiceBackend {
     };
   }
 
-  public RestBackend.Delete<ServiceParameters> delete() {
+  public RestBackend.Delete<IdentifiableServiceParameters> delete() {
     return params -> {
       sps.deleteTechnicalService(params.getId());
       return true;

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TechnicalServiceResource.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TechnicalServiceResource.java
@@ -35,6 +35,7 @@ import org.oscm.rest.common.CommonParams;
 import org.oscm.rest.common.RestResource;
 import org.oscm.rest.common.Since;
 import org.oscm.rest.common.representation.TechnicalServiceRepresentation;
+import org.oscm.rest.common.requestparameters.IdentifiableServiceParameters;
 import org.oscm.rest.common.requestparameters.ServiceParameters;
 
 @Path(CommonParams.PATH_VERSION + "/technicalservices")
@@ -68,7 +69,7 @@ public class TechnicalServiceResource extends RestResource {
   }
 
   public Response exportTechnicalService(
-      @Context UriInfo uriInfo, @BeanParam ServiceParameters params) throws Exception {
+      @Context UriInfo uriInfo, @BeanParam IdentifiableServiceParameters params) throws Exception {
     // FIXME: Implement this endpoint properly. Use get() from interface
     // FIXME: Document this endpoint using Swagger
     // key needed
@@ -139,7 +140,7 @@ public class TechnicalServiceResource extends RestResource {
         @ApiResponse(responseCode = "204", description = "Technical service deleted successfully")
       })
   public Response deleteTechnicalService(
-      @Context UriInfo uriInfo, @BeanParam ServiceParameters params) throws Exception {
+      @Context UriInfo uriInfo, @BeanParam IdentifiableServiceParameters params) throws Exception {
     return delete(uriInfo, tsb.delete(), params);
   }
 }

--- a/oscm-rest-api-service/src/test/java/org/oscm/rest/service/CompatibleServiceResourceTest.java
+++ b/oscm-rest-api-service/src/test/java/org/oscm/rest/service/CompatibleServiceResourceTest.java
@@ -20,6 +20,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.SampleTestDataUtility;
+import org.oscm.rest.common.requestparameters.IdentifiableServiceParameters;
 import org.oscm.rest.common.requestparameters.ServiceParameters;
 import org.oscm.rest.common.representation.ServiceRepresentation;
 
@@ -41,12 +42,14 @@ public class CompatibleServiceResourceTest {
   private ServiceRepresentation serviceRepresentation;
   private UriInfo uriInfo;
   private ServiceParameters serviceParameters;
+  private IdentifiableServiceParameters indentifiableServiceParameters;
 
   @BeforeEach
   public void setUp() {
     serviceRepresentation = SampleTestDataUtility.createServiceRepresentation();
     uriInfo = SampleTestDataUtility.createUriInfo();
     serviceParameters = SampleTestDataUtility.createServiceParameters();
+    indentifiableServiceParameters = SampleTestDataUtility.createIdentifiableServiceParameters();
   }
 
   @AfterEach
@@ -62,7 +65,7 @@ public class CompatibleServiceResourceTest {
                 new RepresentationCollection<>(Lists.newArrayList(serviceRepresentation)));
 
     try {
-      response = compatibleServiceResource.getCompatibleServices(uriInfo, serviceParameters);
+      response = compatibleServiceResource.getCompatibleServices(uriInfo, indentifiableServiceParameters);
     } catch (Exception e) {
       fail(e);
     }
@@ -89,7 +92,7 @@ public class CompatibleServiceResourceTest {
 
     try {
       response =
-          compatibleServiceResource.setCompatibleServices(uriInfo, getContent(), serviceParameters);
+          compatibleServiceResource.setCompatibleServices(uriInfo, getContent(), indentifiableServiceParameters);
     } catch (Exception e) {
       fail(e);
     }

--- a/oscm-rest-api-service/src/test/java/org/oscm/rest/service/PriceModelBackendTest.java
+++ b/oscm-rest-api-service/src/test/java/org/oscm/rest/service/PriceModelBackendTest.java
@@ -11,6 +11,7 @@ import org.oscm.internal.intf.ServiceProvisioningService;
 import org.oscm.internal.vo.VOPriceModel;
 import org.oscm.internal.vo.VOServiceDetails;
 import org.oscm.rest.common.SampleTestDataUtility;
+import org.oscm.rest.common.requestparameters.IdentifiableServiceParameters;
 import org.oscm.rest.common.requestparameters.ServiceParameters;
 import org.oscm.rest.common.representation.PriceModelRepresentation;
 
@@ -30,6 +31,7 @@ public class PriceModelBackendTest {
 
   private UriInfo uriInfo;
   private ServiceParameters parameters;
+  private IdentifiableServiceParameters indentifiableParameters;
   private PriceModelRepresentation representation;
   private VOServiceDetails vo;
 
@@ -38,6 +40,7 @@ public class PriceModelBackendTest {
     resource = new PriceModelResource();
     uriInfo = SampleTestDataUtility.createUriInfo();
     parameters = SampleTestDataUtility.createServiceParameters();
+    indentifiableParameters = SampleTestDataUtility.createIdentifiableServiceParameters();
     representation = SampleTestDataUtility.createPriceModelRepresentation();
     vo = SampleTestDataUtility.createVOServiceDetails();
     resource.setPmb(backend);
@@ -48,7 +51,7 @@ public class PriceModelBackendTest {
   public void shouldGetPricemodel() {
     when(service.getServiceDetails(any())).thenReturn(vo);
 
-    Response response = resource.get(uriInfo, parameters);
+    Response response = resource.get(uriInfo, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -61,7 +64,7 @@ public class PriceModelBackendTest {
   public void shouldGetPricemodelForCustomer() {
     when(service.getServiceForCustomer(any(), any())).thenReturn(vo);
 
-    Response response = resource.getForCustomer(uriInfo, parameters);
+    Response response = resource.getForCustomer(uriInfo, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -74,7 +77,7 @@ public class PriceModelBackendTest {
   public void shouldUpdatePricemodel() {
     when(service.savePriceModel(any(), any())).thenReturn(vo);
 
-    Response response = resource.update(uriInfo, representation, parameters);
+    Response response = resource.update(uriInfo, representation, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -87,7 +90,7 @@ public class PriceModelBackendTest {
   public void shouldUpdatePricemodelForCustomer() {
     when(service.savePriceModelForCustomer(any(), any(), any())).thenReturn(vo);
 
-    Response response = resource.updateForCustomer(uriInfo, representation, parameters);
+    Response response = resource.updateForCustomer(uriInfo, representation, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)

--- a/oscm-rest-api-service/src/test/java/org/oscm/rest/service/PriceModelResourceTest.java
+++ b/oscm-rest-api-service/src/test/java/org/oscm/rest/service/PriceModelResourceTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.oscm.rest.common.SampleTestDataUtility;
+import org.oscm.rest.common.requestparameters.IdentifiableServiceParameters;
 import org.oscm.rest.common.requestparameters.ServiceParameters;
 import org.oscm.rest.common.representation.PriceModelRepresentation;
 import org.oscm.rest.common.representation.ServiceRepresentation;
@@ -41,6 +42,7 @@ public class PriceModelResourceTest {
   private PriceModelRepresentation priceModelRepresentation;
   private UriInfo uriInfo;
   private ServiceParameters serviceParameters;
+  private IdentifiableServiceParameters identifiableServiceParameters;
 
   @BeforeEach
   public void setUp() {
@@ -48,6 +50,7 @@ public class PriceModelResourceTest {
     priceModelRepresentation = SampleTestDataUtility.createPriceModelRepresentation();
     uriInfo = SampleTestDataUtility.createUriInfo();
     serviceParameters = SampleTestDataUtility.createServiceParameters();
+    identifiableServiceParameters = SampleTestDataUtility.createIdentifiableServiceParameters();
   }
 
   @AfterEach
@@ -60,7 +63,7 @@ public class PriceModelResourceTest {
     when(priceModelBackend.get()).thenReturn(serviceParameters1 -> priceModelRepresentation);
 
     try {
-      response = priceModelResource.get(uriInfo, serviceParameters);
+      response = priceModelResource.get(uriInfo, identifiableServiceParameters);
     } catch (Exception e) {
       fail(e);
     }
@@ -79,7 +82,7 @@ public class PriceModelResourceTest {
         .thenReturn((priceModelRepresentation1, serviceParameters1) -> true);
 
     try {
-      response = priceModelResource.update(uriInfo, priceModelRepresentation, serviceParameters);
+      response = priceModelResource.update(uriInfo, priceModelRepresentation, identifiableServiceParameters);
     } catch (Exception e) {
       fail(e);
     }
@@ -97,7 +100,7 @@ public class PriceModelResourceTest {
         .thenReturn(serviceParameters1 -> priceModelRepresentation);
 
     try {
-      response = priceModelResource.getForCustomer(uriInfo, serviceParameters);
+      response = priceModelResource.getForCustomer(uriInfo, identifiableServiceParameters);
     } catch (Exception e) {
       fail(e);
     }
@@ -118,7 +121,7 @@ public class PriceModelResourceTest {
     try {
       response =
           priceModelResource.updateForCustomer(
-              uriInfo, priceModelRepresentation, serviceParameters);
+              uriInfo, priceModelRepresentation, identifiableServiceParameters);
     } catch (Exception e) {
       fail(e);
     }

--- a/oscm-rest-api-service/src/test/java/org/oscm/rest/service/ServiceBackendTest.java
+++ b/oscm-rest-api-service/src/test/java/org/oscm/rest/service/ServiceBackendTest.java
@@ -16,6 +16,7 @@ import org.oscm.internal.vo.VOTechnicalService;
 import org.oscm.rest.common.ServiceStatus;
 import org.oscm.rest.common.representation.*;
 import org.oscm.rest.common.SampleTestDataUtility;
+import org.oscm.rest.common.requestparameters.IdentifiableServiceParameters;
 import org.oscm.rest.common.requestparameters.ServiceParameters;
 
 import javax.ws.rs.core.Response;
@@ -34,6 +35,7 @@ public class ServiceBackendTest {
   private CompatibleServiceResource compatiblesResource;
   private UriInfo uriInfo;
   private ServiceParameters parameters;
+  private IdentifiableServiceParameters indentifiableParameters;
   private ServiceDetailsRepresentation representation;
   private StatusRepresentation statusRepresentation;
   private VOServiceDetails vo;
@@ -45,6 +47,7 @@ public class ServiceBackendTest {
     compatiblesResource = new CompatibleServiceResource();
     uriInfo = SampleTestDataUtility.createUriInfo();
     parameters = SampleTestDataUtility.createServiceParameters();
+    indentifiableParameters = SampleTestDataUtility.createIdentifiableServiceParameters();
     representation = SampleTestDataUtility.createServiceDetailsRepresentation(null);
     statusRepresentation = SampleTestDataUtility.createStatusRepresentation();
     compatiblesCollection = createCompatiblesCollection();
@@ -58,7 +61,7 @@ public class ServiceBackendTest {
   public void shouldGetService() {
     when(service.getServiceDetails(any())).thenReturn(vo);
 
-    Response response = resource.getService(uriInfo, parameters);
+    Response response = resource.getService(uriInfo, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -103,7 +106,7 @@ public class ServiceBackendTest {
   public void shouldUpdateService() {
     when(service.updateService(any(), any())).thenReturn(vo);
 
-    Response response = resource.updateService(uriInfo, representation, parameters);
+    Response response = resource.updateService(uriInfo, representation, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -116,7 +119,7 @@ public class ServiceBackendTest {
   public void shouldDeleteService() {
     doNothing().when(service).deleteService(any(Long.class));
 
-    Response response = resource.deleteService(uriInfo, parameters);
+    Response response = resource.deleteService(uriInfo, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -134,7 +137,7 @@ public class ServiceBackendTest {
     lenient().when(service.suspendService(any(), any())).thenReturn(vo);
     statusRepresentation.setStatus(serviceStatus);
 
-    Response response = resource.setServiceState(uriInfo, statusRepresentation, parameters);
+    Response response = resource.setServiceState(uriInfo, statusRepresentation, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -147,7 +150,7 @@ public class ServiceBackendTest {
   public void shouldGetCompatibleServices() {
     when(service.getCompatibleServices(any())).thenReturn(Lists.newArrayList(vo));
 
-    Response response = compatiblesResource.getCompatibleServices(uriInfo, parameters);
+    Response response = compatiblesResource.getCompatibleServices(uriInfo, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -161,7 +164,7 @@ public class ServiceBackendTest {
     doNothing().when(service).setCompatibleServices(any(), any());
 
     Response response =
-        compatiblesResource.setCompatibleServices(uriInfo, compatiblesCollection, parameters);
+        compatiblesResource.setCompatibleServices(uriInfo, compatiblesCollection, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)

--- a/oscm-rest-api-service/src/test/java/org/oscm/rest/service/ServiceResourceTest.java
+++ b/oscm-rest-api-service/src/test/java/org/oscm/rest/service/ServiceResourceTest.java
@@ -22,6 +22,7 @@ import org.oscm.internal.vo.VOServiceDetails;
 import org.oscm.internal.vo.VOTechnicalService;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.SampleTestDataUtility;
+import org.oscm.rest.common.requestparameters.IdentifiableServiceParameters;
 import org.oscm.rest.common.requestparameters.ServiceParameters;
 import org.oscm.rest.common.representation.ServiceDetailsRepresentation;
 import org.oscm.rest.common.representation.ServiceRepresentation;
@@ -46,6 +47,7 @@ public class ServiceResourceTest {
   private ServiceDetailsRepresentation serviceDetailsRepresentation;
   private UriInfo uriInfo;
   private ServiceParameters serviceParameters;
+  private IdentifiableServiceParameters identifiableServiceParameters;
   private StatusRepresentation statusRepresentation;
   private VOServiceDetails voServiceDetails;
 
@@ -57,6 +59,7 @@ public class ServiceResourceTest {
     statusRepresentation = SampleTestDataUtility.createStatusRepresentation();
     uriInfo = SampleTestDataUtility.createUriInfo();
     serviceParameters = SampleTestDataUtility.createServiceParameters();
+    identifiableServiceParameters = SampleTestDataUtility.createIdentifiableServiceParameters();
   }
 
   @AfterEach
@@ -116,7 +119,7 @@ public class ServiceResourceTest {
     when(serviceBackend.get()).thenReturn(serviceParameters1 -> serviceDetailsRepresentation);
 
     try {
-      response = serviceResource.getService(uriInfo, serviceParameters);
+      response = serviceResource.getService(uriInfo, identifiableServiceParameters);
     } catch (Exception e) {
       fail(e);
     }
@@ -136,7 +139,7 @@ public class ServiceResourceTest {
 
     try {
       response =
-          serviceResource.updateService(uriInfo, serviceDetailsRepresentation, serviceParameters);
+          serviceResource.updateService(uriInfo, serviceDetailsRepresentation, identifiableServiceParameters);
     } catch (Exception e) {
       fail(e);
     }
@@ -153,7 +156,7 @@ public class ServiceResourceTest {
     when(serviceBackend.delete()).thenReturn(serviceParameters1 -> true);
 
     try {
-      response = serviceResource.deleteService(uriInfo, serviceParameters);
+      response = serviceResource.deleteService(uriInfo, identifiableServiceParameters);
     } catch (Exception e) {
       fail(e);
     }
@@ -171,7 +174,7 @@ public class ServiceResourceTest {
         .thenReturn((statusRepresentation1, serviceParameters1) -> true);
 
     try {
-      response = serviceResource.setServiceState(uriInfo, statusRepresentation, serviceParameters);
+      response = serviceResource.setServiceState(uriInfo, statusRepresentation, identifiableServiceParameters);
     } catch (Exception e) {
       fail(e);
     }

--- a/oscm-rest-api-service/src/test/java/org/oscm/rest/service/TSSupplierBackendTest.java
+++ b/oscm-rest-api-service/src/test/java/org/oscm/rest/service/TSSupplierBackendTest.java
@@ -12,6 +12,7 @@ import org.oscm.internal.intf.AccountService;
 import org.oscm.internal.vo.VOOrganization;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.SampleTestDataUtility;
+import org.oscm.rest.common.requestparameters.IdentifiableServiceParameters;
 import org.oscm.rest.common.requestparameters.ServiceParameters;
 import org.oscm.rest.common.representation.OrganizationRepresentation;
 
@@ -32,6 +33,7 @@ public class TSSupplierBackendTest {
 
   private OrganizationRepresentation representation;
   private ServiceParameters parameters;
+  private IdentifiableServiceParameters indentifiableParameters;
   private UriInfo uriInfo;
   private VOOrganization vo;
 
@@ -42,6 +44,7 @@ public class TSSupplierBackendTest {
     vo = SampleTestDataUtility.createVOOrganization();
     representation = SampleTestDataUtility.createOrgRepresentation();
     parameters = SampleTestDataUtility.createServiceParameters();
+    indentifiableParameters = SampleTestDataUtility.createIdentifiableServiceParameters();
     uriInfo = SampleTestDataUtility.createUriInfo();
   }
 
@@ -51,7 +54,7 @@ public class TSSupplierBackendTest {
     when(service.getSuppliersForTechnicalService(any()))
         .thenReturn(Lists.newArrayList(new VOOrganization()));
 
-    Response response = resource.getSuppliers(uriInfo, parameters);
+    Response response = resource.getSuppliers(uriInfo, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -73,7 +76,7 @@ public class TSSupplierBackendTest {
   public void shouldAddSupplier() {
     doNothing().when(service).addSuppliersForTechnicalService(any(), any());
 
-    Response response = resource.addSupplier(uriInfo, representation, parameters);
+    Response response = resource.addSupplier(uriInfo, representation, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -86,7 +89,7 @@ public class TSSupplierBackendTest {
   public void shouldDeleteSupplier() {
     doNothing().when(service).removeSuppliersFromTechnicalService(any(), any());
 
-    Response response = resource.removeSupplier(uriInfo, parameters);
+    Response response = resource.removeSupplier(uriInfo, indentifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)

--- a/oscm-rest-api-service/src/test/java/org/oscm/rest/service/TSSupplierResourceTest.java
+++ b/oscm-rest-api-service/src/test/java/org/oscm/rest/service/TSSupplierResourceTest.java
@@ -20,6 +20,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.SampleTestDataUtility;
+import org.oscm.rest.common.requestparameters.IdentifiableServiceParameters;
 import org.oscm.rest.common.requestparameters.ServiceParameters;
 import org.oscm.rest.common.representation.OrganizationRepresentation;
 import org.oscm.rest.common.representation.ServiceRepresentation;
@@ -42,12 +43,14 @@ public class TSSupplierResourceTest {
   private OrganizationRepresentation organizationRepresentation;
   private UriInfo uriInfo;
   private ServiceParameters serviceParameters;
+  private IdentifiableServiceParameters identifiableServiceParameters;
 
   @BeforeEach
   public void setUp() {
     organizationRepresentation = SampleTestDataUtility.createOrgRepresentation();
     uriInfo = SampleTestDataUtility.createUriInfo();
     serviceParameters = SampleTestDataUtility.createServiceParameters();
+    identifiableServiceParameters = SampleTestDataUtility.createIdentifiableServiceParameters();
   }
 
   @AfterEach
@@ -63,7 +66,7 @@ public class TSSupplierResourceTest {
                 new RepresentationCollection<>(Lists.newArrayList(organizationRepresentation)));
 
     try {
-      response = tsSupplierResource.getSuppliers(uriInfo, serviceParameters);
+      response = tsSupplierResource.getSuppliers(uriInfo, identifiableServiceParameters);
     } catch (Exception e) {
       fail(e);
     }
@@ -90,7 +93,7 @@ public class TSSupplierResourceTest {
 
     try {
       response =
-          tsSupplierResource.addSupplier(uriInfo, organizationRepresentation, serviceParameters);
+          tsSupplierResource.addSupplier(uriInfo, organizationRepresentation, identifiableServiceParameters);
     } catch (Exception e) {
       fail(e);
     }
@@ -107,7 +110,7 @@ public class TSSupplierResourceTest {
     when(tsSupplierBackend.delete()).thenReturn(serviceParameters1 -> true);
 
     try {
-      response = tsSupplierResource.removeSupplier(uriInfo, serviceParameters);
+      response = tsSupplierResource.removeSupplier(uriInfo, identifiableServiceParameters);
     } catch (Exception e) {
       fail(e);
     }

--- a/oscm-rest-api-service/src/test/java/org/oscm/rest/service/TechnicalServiceBackendTest.java
+++ b/oscm-rest-api-service/src/test/java/org/oscm/rest/service/TechnicalServiceBackendTest.java
@@ -13,6 +13,7 @@ import org.oscm.internal.intf.ServiceProvisioningService;
 import org.oscm.internal.vo.VOTechnicalService;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.SampleTestDataUtility;
+import org.oscm.rest.common.requestparameters.IdentifiableServiceParameters;
 import org.oscm.rest.common.requestparameters.ServiceParameters;
 import org.oscm.rest.common.representation.TechnicalServiceRepresentation;
 
@@ -32,6 +33,7 @@ public class TechnicalServiceBackendTest {
   private TechnicalServiceResource resource;
   private UriInfo uriInfo;
   private ServiceParameters parameters;
+  private IdentifiableServiceParameters identifiableParameters;
   private TechnicalServiceRepresentation representation;
 
   @BeforeEach
@@ -39,6 +41,7 @@ public class TechnicalServiceBackendTest {
     resource = new TechnicalServiceResource();
     uriInfo = SampleTestDataUtility.createUriInfo();
     parameters = SampleTestDataUtility.createServiceParameters();
+    identifiableParameters = SampleTestDataUtility.createIdentifiableServiceParameters();
     representation = SampleTestDataUtility.createTSRepresentation();
     resource.setTsb(backend);
   }
@@ -88,7 +91,7 @@ public class TechnicalServiceBackendTest {
   public void shouldDeleteTechnicalService() {
     doNothing().when(service).deleteTechnicalService(any(Long.class));
 
-    Response response = resource.deleteTechnicalService(uriInfo, parameters);
+    Response response = resource.deleteTechnicalService(uriInfo, identifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)

--- a/oscm-rest-api-service/src/test/java/org/oscm/rest/service/TechnicalServiceResourceTest.java
+++ b/oscm-rest-api-service/src/test/java/org/oscm/rest/service/TechnicalServiceResourceTest.java
@@ -22,6 +22,7 @@ import org.oscm.internal.intf.ServiceProvisioningService;
 import org.oscm.internal.types.exception.*;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.SampleTestDataUtility;
+import org.oscm.rest.common.requestparameters.IdentifiableServiceParameters;
 import org.oscm.rest.common.requestparameters.ServiceParameters;
 import org.oscm.rest.common.representation.ServiceRepresentation;
 import org.oscm.rest.common.representation.TechnicalServiceRepresentation;
@@ -48,12 +49,14 @@ public class TechnicalServiceResourceTest {
   private TechnicalServiceRepresentation technicalServiceRepresentation;
   private UriInfo uriInfo;
   private ServiceParameters serviceParameters;
+  private IdentifiableServiceParameters indentifiableParameters;
 
   @BeforeEach
   public void setUp() {
     technicalServiceRepresentation = SampleTestDataUtility.createTSRepresentation();
     uriInfo = SampleTestDataUtility.createUriInfo();
     serviceParameters = SampleTestDataUtility.createServiceParameters();
+    indentifiableParameters = SampleTestDataUtility.createIdentifiableServiceParameters();
   }
 
   @AfterEach
@@ -114,7 +117,7 @@ public class TechnicalServiceResourceTest {
     when(technicalServiceBackend.delete()).thenReturn(serviceParameters1 -> true);
 
     try {
-      response = technicalServiceResource.deleteTechnicalService(uriInfo, serviceParameters);
+      response = technicalServiceResource.deleteTechnicalService(uriInfo, indentifiableParameters);
     } catch (Exception e) {
       fail(e);
     }
@@ -137,7 +140,7 @@ public class TechnicalServiceResourceTest {
     }
 
     try {
-      response = technicalServiceResource.exportTechnicalService(uriInfo, serviceParameters);
+      response = technicalServiceResource.exportTechnicalService(uriInfo, indentifiableParameters);
     } catch (Exception e) {
       fail(e);
     }

--- a/oscm-rest-api-subscription/src/main/java/org/oscm/rest/subscription/SubscriptionBackend.java
+++ b/oscm-rest-api-subscription/src/main/java/org/oscm/rest/subscription/SubscriptionBackend.java
@@ -23,6 +23,7 @@ import org.oscm.internal.vo.VOSubscriptionDetails;
 import org.oscm.internal.vo.VOUser;
 import org.oscm.rest.common.RestBackend;
 import org.oscm.rest.common.representation.*;
+import org.oscm.rest.common.requestparameters.IdentifiableSubscriptionParameters;
 import org.oscm.rest.common.requestparameters.SubscriptionParameters;
 
 @Stateless
@@ -59,11 +60,11 @@ public class SubscriptionBackend {
     };
   }
 
-  public RestBackend.Delete<SubscriptionParameters> delete() {
+  public RestBackend.Delete<IdentifiableSubscriptionParameters> delete() {
     return params -> ss.unsubscribeFromService(params.getId());
   }
 
-  public RestBackend.Get<SubscriptionDetailsRepresentation, SubscriptionParameters> get() {
+  public RestBackend.Get<SubscriptionDetailsRepresentation, IdentifiableSubscriptionParameters> get() {
     return params -> {
       VOSubscriptionDetails sub = ss.getSubscriptionDetails(params.getId().longValue());
       return new SubscriptionDetailsRepresentation(sub);
@@ -90,7 +91,7 @@ public class SubscriptionBackend {
     };
   }
 
-  public RestBackend.Put<SubscriptionCreationRepresentation, SubscriptionParameters> put() {
+  public RestBackend.Put<SubscriptionCreationRepresentation, IdentifiableSubscriptionParameters> put() {
     return (content, params) -> {
       content.getService().update();
       content.getUdaRepresentations().forEach(UdaRepresentation::update);

--- a/oscm-rest-api-subscription/src/main/java/org/oscm/rest/subscription/SubscriptionResource.java
+++ b/oscm-rest-api-subscription/src/main/java/org/oscm/rest/subscription/SubscriptionResource.java
@@ -29,6 +29,7 @@ import org.oscm.rest.common.CommonParams;
 import org.oscm.rest.common.RestResource;
 import org.oscm.rest.common.Since;
 import org.oscm.rest.common.representation.SubscriptionCreationRepresentation;
+import org.oscm.rest.common.requestparameters.IdentifiableSubscriptionParameters;
 import org.oscm.rest.common.requestparameters.SubscriptionParameters;
 
 @Path(CommonParams.PATH_VERSION + "/subscriptions")
@@ -75,7 +76,7 @@ public class SubscriptionResource extends RestResource {
                     schema = @Schema(implementation = SubscriptionCreationRepresentation.class)))
       })
   public Response getSubscription(
-      @Context UriInfo uriInfo, @BeanParam SubscriptionParameters params) throws Exception {
+      @Context UriInfo uriInfo, @BeanParam IdentifiableSubscriptionParameters params) throws Exception {
     return get(uriInfo, sb.get(), params, true);
   }
 
@@ -143,7 +144,7 @@ public class SubscriptionResource extends RestResource {
   public Response updateSubscription(
       @Context UriInfo uriInfo,
       SubscriptionCreationRepresentation content,
-      @BeanParam SubscriptionParameters params)
+      @BeanParam IdentifiableSubscriptionParameters params)
       throws Exception {
     return put(uriInfo, sb.put(), content, params);
   }
@@ -159,7 +160,7 @@ public class SubscriptionResource extends RestResource {
         @ApiResponse(responseCode = "204", description = "Subscription deleted successfully")
       })
   public Response deleteSubscription(
-      @Context UriInfo uriInfo, @BeanParam SubscriptionParameters params) throws Exception {
+      @Context UriInfo uriInfo, @BeanParam IdentifiableSubscriptionParameters params) throws Exception {
     return delete(uriInfo, sb.delete(), params);
   }
 }

--- a/oscm-rest-api-subscription/src/main/java/org/oscm/rest/subscription/UsageLicenseBackend.java
+++ b/oscm-rest-api-subscription/src/main/java/org/oscm/rest/subscription/UsageLicenseBackend.java
@@ -19,6 +19,7 @@ import org.oscm.internal.vo.VOUsageLicense;
 import org.oscm.rest.common.RestBackend;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.representation.UsageLicenseRepresentation;
+import org.oscm.rest.common.requestparameters.IdentifiableSubscriptionParameters;
 import org.oscm.rest.common.requestparameters.SubscriptionParameters;
 
 @Stateless
@@ -26,7 +27,7 @@ public class UsageLicenseBackend {
 
   @EJB SubscriptionService ss;
 
-  public RestBackend.Post<UsageLicenseRepresentation, SubscriptionParameters> post() {
+  public RestBackend.Post<UsageLicenseRepresentation, IdentifiableSubscriptionParameters> post() {
     return (content, params) -> {
       content.update();
 
@@ -49,7 +50,7 @@ public class UsageLicenseBackend {
     };
   }
 
-  public RestBackend.GetCollection<UsageLicenseRepresentation, SubscriptionParameters>
+  public RestBackend.GetCollection<UsageLicenseRepresentation, IdentifiableSubscriptionParameters>
       getCollection() {
     return params -> {
       VOSubscriptionDetails sub = ss.getSubscriptionDetails(params.getId().longValue());
@@ -59,7 +60,7 @@ public class UsageLicenseBackend {
     };
   }
 
-  public RestBackend.Put<UsageLicenseRepresentation, SubscriptionParameters> put() {
+  public RestBackend.Put<UsageLicenseRepresentation, IdentifiableSubscriptionParameters> put() {
     return (content, params) -> {
       content.update();
 
@@ -70,7 +71,7 @@ public class UsageLicenseBackend {
     };
   }
 
-  public RestBackend.Delete<SubscriptionParameters> delete() {
+  public RestBackend.Delete<IdentifiableSubscriptionParameters> delete() {
     return params -> {
       VOSubscriptionDetails sub = ss.getSubscriptionDetails(params.getId().longValue());
       List<VOUsageLicense> lics = sub.getUsageLicenses();

--- a/oscm-rest-api-subscription/src/main/java/org/oscm/rest/subscription/UsageLicenseResource.java
+++ b/oscm-rest-api-subscription/src/main/java/org/oscm/rest/subscription/UsageLicenseResource.java
@@ -29,6 +29,7 @@ import org.oscm.rest.common.CommonParams;
 import org.oscm.rest.common.RestResource;
 import org.oscm.rest.common.Since;
 import org.oscm.rest.common.representation.UsageLicenseRepresentation;
+import org.oscm.rest.common.requestparameters.IdentifiableSubscriptionParameters;
 import org.oscm.rest.common.requestparameters.SubscriptionParameters;
 
 @Path(CommonParams.PATH_VERSION + "/subscriptions" + CommonParams.PATH_ID + "/usagelicenses")
@@ -54,7 +55,7 @@ public class UsageLicenseResource extends RestResource {
                     mediaType = "application/json",
                     schema = @Schema(implementation = UsageLicenseRepresentation.class)))
       })
-  public Response getLicenses(@Context UriInfo uriInfo, @BeanParam SubscriptionParameters params)
+  public Response getLicenses(@Context UriInfo uriInfo, @BeanParam IdentifiableSubscriptionParameters params)
       throws Exception {
     return getCollection(uriInfo, ulb.getCollection(), params);
   }
@@ -88,7 +89,7 @@ public class UsageLicenseResource extends RestResource {
   public Response createLicense(
       @Context UriInfo uriInfo,
       UsageLicenseRepresentation content,
-      @BeanParam SubscriptionParameters params)
+      @BeanParam IdentifiableSubscriptionParameters params)
       throws Exception {
     return post(uriInfo, ulb.post(), content, params);
   }
@@ -123,7 +124,7 @@ public class UsageLicenseResource extends RestResource {
   public Response updateLicense(
       @Context UriInfo uriInfo,
       UsageLicenseRepresentation content,
-      @BeanParam SubscriptionParameters params)
+      @BeanParam IdentifiableSubscriptionParameters params)
       throws Exception {
     return put(uriInfo, ulb.put(), content, params);
   }
@@ -138,7 +139,7 @@ public class UsageLicenseResource extends RestResource {
       responses = {
         @ApiResponse(responseCode = "204", description = "Usage license deleted successfully")
       })
-  public Response deleteLicense(@Context UriInfo uriInfo, @BeanParam SubscriptionParameters params)
+  public Response deleteLicense(@Context UriInfo uriInfo, @BeanParam IdentifiableSubscriptionParameters params)
       throws Exception {
     return delete(uriInfo, ulb.delete(), params);
   }

--- a/oscm-rest-api-subscription/src/test/java/org/oscm/rest/subscription/SubscriptionBackendTest.java
+++ b/oscm-rest-api-subscription/src/test/java/org/oscm/rest/subscription/SubscriptionBackendTest.java
@@ -13,6 +13,7 @@ import org.oscm.internal.intf.SubscriptionServiceInternal;
 import org.oscm.internal.vo.*;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.SampleTestDataUtility;
+import org.oscm.rest.common.requestparameters.IdentifiableSubscriptionParameters;
 import org.oscm.rest.common.requestparameters.SubscriptionParameters;
 import org.oscm.rest.common.representation.ServiceRepresentation;
 import org.oscm.rest.common.representation.SubscriptionCreationRepresentation;
@@ -37,6 +38,7 @@ public class SubscriptionBackendTest {
   private UriInfo uriInfo;
   private SubscriptionCreationRepresentation representation;
   private SubscriptionParameters parameters;
+  private IdentifiableSubscriptionParameters identifiableParameters;
   private VOUserSubscription voUserSubscription;
   private VOSubscriptionDetails voSubscriptionDetails;
   private VOSubscription voSubscription;
@@ -48,6 +50,7 @@ public class SubscriptionBackendTest {
     uriInfo = SampleTestDataUtility.createUriInfo();
     representation = SampleTestDataUtility.createSubscriptionCreationRepresentation();
     parameters = SampleTestDataUtility.createSubscriptionParameters();
+    identifiableParameters = SampleTestDataUtility.createIdentifiableSubscriptionParameters();
     voUserSubscription = SampleTestDataUtility.createVOUserSubscription();
     voSubscriptionDetails = SampleTestDataUtility.createVOSubscriptionDetails();
     voSubscription = SampleTestDataUtility.createVOSubscription();
@@ -101,7 +104,7 @@ public class SubscriptionBackendTest {
   public void shouldGetSubscriptionById() {
     when(service.getSubscriptionDetails(anyLong())).thenReturn(voSubscriptionDetails);
 
-    Response response = resource.getSubscription(uriInfo, parameters);
+    Response response = resource.getSubscription(uriInfo, identifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -129,7 +132,7 @@ public class SubscriptionBackendTest {
   public void shouldUpdateSubscription() {
     when(service.modifySubscription(any(), any(), any())).thenReturn(voSubscriptionDetails);
 
-    Response response = resource.updateSubscription(uriInfo, representation, parameters);
+    Response response = resource.updateSubscription(uriInfo, representation, identifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -142,7 +145,7 @@ public class SubscriptionBackendTest {
   public void shouldDeleteSubscription() {
     when(service.unsubscribeFromService(anyLong())).thenReturn(true);
 
-    Response response = resource.deleteSubscription(uriInfo, parameters);
+    Response response = resource.deleteSubscription(uriInfo, identifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)

--- a/oscm-rest-api-subscription/src/test/java/org/oscm/rest/subscription/SubscriptionResourceTest.java
+++ b/oscm-rest-api-subscription/src/test/java/org/oscm/rest/subscription/SubscriptionResourceTest.java
@@ -14,6 +14,7 @@ import org.oscm.internal.vo.VOService;
 import org.oscm.internal.vo.VOSubscriptionDetails;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.SampleTestDataUtility;
+import org.oscm.rest.common.requestparameters.IdentifiableSubscriptionParameters;
 import org.oscm.rest.common.requestparameters.SubscriptionParameters;
 import org.oscm.rest.common.representation.SubscriptionCreationRepresentation;
 import org.oscm.rest.common.representation.SubscriptionDetailsRepresentation;
@@ -41,6 +42,7 @@ public class SubscriptionResourceTest {
     private SubscriptionDetailsRepresentation subscriptionDetailsRepresentation;
     private SubscriptionCreationRepresentation subscriptionCreationRepresentation;
     private SubscriptionParameters subscriptionParameters;
+    private IdentifiableSubscriptionParameters identifiableSubscriptionParameters;
     private UriInfo uriInfo;
     private VOSubscriptionDetails voSubscriptionDetails;
 
@@ -51,6 +53,7 @@ public class SubscriptionResourceTest {
         subscriptionDetailsRepresentation = SampleTestDataUtility.createSubscriptionDetailsRepresentation(voSubscriptionDetails);
         subscriptionCreationRepresentation = SampleTestDataUtility.createSubscriptionCreationRepresentation();
         subscriptionParameters = SampleTestDataUtility.createSubscriptionParameters();
+        identifiableSubscriptionParameters = SampleTestDataUtility.createIdentifiableSubscriptionParameters();
         uriInfo = SampleTestDataUtility.createUriInfo();
     }
 
@@ -118,7 +121,7 @@ public class SubscriptionResourceTest {
         when(subscriptionBackend.get()).thenReturn(params -> subscriptionDetailsRepresentation);
 
         try {
-            response = subscriptionResource.getSubscription(uriInfo, subscriptionParameters);
+            response = subscriptionResource.getSubscription(uriInfo, identifiableSubscriptionParameters);
         } catch (Exception e) {
             fail(e);
         }
@@ -137,7 +140,7 @@ public class SubscriptionResourceTest {
                 .thenReturn((content, params) -> true);
 
         try {
-            response = subscriptionResource.updateSubscription(uriInfo, subscriptionCreationRepresentation, subscriptionParameters);
+            response = subscriptionResource.updateSubscription(uriInfo, subscriptionCreationRepresentation, identifiableSubscriptionParameters);
         } catch (Exception e) {
             fail(e);
         }
@@ -155,7 +158,7 @@ public class SubscriptionResourceTest {
                 .thenReturn(params -> true);
 
         try {
-            response = subscriptionResource.deleteSubscription(uriInfo, subscriptionParameters);
+            response = subscriptionResource.deleteSubscription(uriInfo, identifiableSubscriptionParameters);
         } catch (Exception e) {
             fail(e);
         }

--- a/oscm-rest-api-subscription/src/test/java/org/oscm/rest/subscription/UsageLicenseBackendTest.java
+++ b/oscm-rest-api-subscription/src/test/java/org/oscm/rest/subscription/UsageLicenseBackendTest.java
@@ -17,6 +17,7 @@ import org.oscm.rest.common.SampleTestDataUtility;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.representation.UsageLicenseRepresentation;
 import org.oscm.rest.common.representation.UserRepresentation;
+import org.oscm.rest.common.requestparameters.IdentifiableSubscriptionParameters;
 import org.oscm.rest.common.requestparameters.SubscriptionParameters;
 
 import javax.ws.rs.core.Response;
@@ -37,6 +38,7 @@ public class UsageLicenseBackendTest {
 
   private UriInfo uriInfo;
   private SubscriptionParameters parameters;
+  private IdentifiableSubscriptionParameters identifiableParameters;
   private UsageLicenseRepresentation representation;
   private VOSubscriptionDetails vo;
 
@@ -46,6 +48,7 @@ public class UsageLicenseBackendTest {
     resource.setUlb(backend);
     uriInfo = SampleTestDataUtility.createUriInfo();
     parameters = SampleTestDataUtility.createSubscriptionParameters();
+    identifiableParameters = SampleTestDataUtility.createIdentifiableSubscriptionParameters();
     representation = SampleTestDataUtility.createUsageLicenseRepresentation(null);
     vo = SampleTestDataUtility.createVOSubscriptionDetails();
   }
@@ -55,7 +58,7 @@ public class UsageLicenseBackendTest {
   public void shouldGetLicenses() {
     doReturn(vo).when(service).getSubscriptionDetails(anyLong());
 
-    Response response = resource.getLicenses(uriInfo, parameters);
+    Response response = resource.getLicenses(uriInfo, identifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -76,7 +79,7 @@ public class UsageLicenseBackendTest {
     when(service.addRevokeUser(any(), any(), any())).thenReturn(true);
     when(service.getSubscriptionDetails(anyLong())).thenReturn(vo);
 
-    Response response = resource.createLicense(uriInfo, representation, parameters);
+    Response response = resource.createLicense(uriInfo, representation, identifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -90,7 +93,7 @@ public class UsageLicenseBackendTest {
     when(service.addRevokeUser(any(), any(), any())).thenReturn(true);
     when(service.getSubscriptionDetails(anyLong())).thenReturn(vo);
 
-    Response response = resource.updateLicense(uriInfo, representation, parameters);
+    Response response = resource.updateLicense(uriInfo, representation, identifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)
@@ -103,7 +106,7 @@ public class UsageLicenseBackendTest {
   public void shouldDeleteLicesne() {
     when(service.getSubscriptionDetails(anyLong())).thenReturn(vo);
 
-    Response response = resource.deleteLicense(uriInfo, parameters);
+    Response response = resource.deleteLicense(uriInfo, identifiableParameters);
 
     assertThat(response).isNotNull();
     assertThat(response)

--- a/oscm-rest-api-subscription/src/test/java/org/oscm/rest/subscription/UsageLicenseResourceTest.java
+++ b/oscm-rest-api-subscription/src/test/java/org/oscm/rest/subscription/UsageLicenseResourceTest.java
@@ -14,6 +14,7 @@ import org.oscm.internal.vo.VOUsageLicense;
 import org.oscm.internal.vo.VOUser;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.SampleTestDataUtility;
+import org.oscm.rest.common.requestparameters.IdentifiableSubscriptionParameters;
 import org.oscm.rest.common.requestparameters.SubscriptionParameters;
 import org.oscm.rest.common.representation.SubscriptionRepresentation;
 import org.oscm.rest.common.representation.UsageLicenseRepresentation;
@@ -38,12 +39,14 @@ public class UsageLicenseResourceTest {
     private Response response;
     private UriInfo uriInfo;
     private SubscriptionParameters subscriptionParameters;
+    private IdentifiableSubscriptionParameters identifiableSubscriptionParameters;
     private SubscriptionRepresentation subscriptionRepresentation;
     private UsageLicenseRepresentation usageLicenseRepresentation;
 
     @BeforeEach
     public void setUp() {
         subscriptionParameters = SampleTestDataUtility.createSubscriptionParameters();
+        identifiableSubscriptionParameters = SampleTestDataUtility.createIdentifiableSubscriptionParameters();
         uriInfo = SampleTestDataUtility.createUriInfo();
         subscriptionRepresentation = SampleTestDataUtility.createSubscriptionRepresentation();
         VOUsageLicense voUsageLicense = SampleTestDataUtility.createVOUsageLicense();
@@ -61,7 +64,7 @@ public class UsageLicenseResourceTest {
                 .thenReturn(params -> new RepresentationCollection<>(Lists.newArrayList(usageLicenseRepresentation)));
 
         try {
-            response = usageLicenseResource.getLicenses(uriInfo, subscriptionParameters);
+            response = usageLicenseResource.getLicenses(uriInfo, identifiableSubscriptionParameters);
         } catch (Exception e) {
             fail(e);
         }
@@ -87,7 +90,7 @@ public class UsageLicenseResourceTest {
                 .thenReturn((content, params) -> true);
 
         try {
-            response = usageLicenseResource.createLicense(uriInfo, usageLicenseRepresentation, subscriptionParameters);
+            response = usageLicenseResource.createLicense(uriInfo, usageLicenseRepresentation, identifiableSubscriptionParameters);
         } catch (Exception e) {
             fail(e);
         }
@@ -105,7 +108,7 @@ public class UsageLicenseResourceTest {
                 .thenReturn((content, params) -> true);
 
         try {
-            response = usageLicenseResource.updateLicense(uriInfo, usageLicenseRepresentation, subscriptionParameters);
+            response = usageLicenseResource.updateLicense(uriInfo, usageLicenseRepresentation, identifiableSubscriptionParameters);
         } catch (Exception e) {
             fail(e);
         }
@@ -123,7 +126,7 @@ public class UsageLicenseResourceTest {
                 .thenReturn(params -> true);
 
         try {
-            response = usageLicenseResource.deleteLicense(uriInfo, subscriptionParameters);
+            response = usageLicenseResource.deleteLicense(uriInfo, identifiableSubscriptionParameters);
         } catch (Exception e) {
             fail(e);
         }


### PR DESCRIPTION
**Changes in this Pull Request:**
- Split RequestParameters into Non-Identifiable and Identifiable (with and without ID path param)

**Mandatory checks:**
- [x] latest changes were fetched from the upstream branch before creating this PR (branch is up to date)
- [x] changes were tested manually
- [x] unit tests were properly implemented
- [x] communication about interdependent changes has been sent to the team (if applicable)
- [x] respective Jenkins jobs were referenced in *additional context* section of this PR

**OSCM Build References:**
N/A

Closes #106 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm-rest-api/171)
<!-- Reviewable:end -->
