### PR TITLE
Post endpoints now returns both key and id

### DIFF
--- a/oscm-rest-api-account/src/main/java/org/oscm/rest/account/AccountBackend.java
+++ b/oscm-rest-api-account/src/main/java/org/oscm/rest/account/AccountBackend.java
@@ -9,10 +9,6 @@
  */
 package org.oscm.rest.account;
 
-import java.util.Collection;
-import java.util.List;
-import javax.ejb.EJB;
-import javax.ejb.Stateless;
 import org.oscm.internal.intf.AccountService;
 import org.oscm.internal.intf.OperatorService;
 import org.oscm.internal.types.exception.DomainObjectException.ClassEnum;
@@ -20,9 +16,15 @@ import org.oscm.internal.types.exception.ObjectNotFoundException;
 import org.oscm.internal.vo.VOBillingContact;
 import org.oscm.internal.vo.VOOrganization;
 import org.oscm.internal.vo.VOPaymentInfo;
+import org.oscm.rest.common.PostResponseBody;
 import org.oscm.rest.common.RestBackend;
 import org.oscm.rest.common.representation.*;
 import org.oscm.rest.common.requestparameters.AccountParameters;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import java.util.Collection;
+import java.util.List;
 
 @Stateless
 public class AccountBackend {
@@ -31,10 +33,14 @@ public class AccountBackend {
 
   @EJB OperatorService os;
 
+  //TODO: Test
   public RestBackend.Post<BillingContactRepresentation, AccountParameters> postBillingContact() {
     return (content, params) -> {
       VOBillingContact vo = content.getVO();
-      return String.valueOf(as.saveBillingContact(vo).getKey());
+      VOBillingContact responseVO = as.saveBillingContact(vo);
+      return PostResponseBody.of()
+          .createdObjectName(vo.getId())
+          .createdObjectId(String.valueOf(vo.getKey()));
     };
   }
 

--- a/oscm-rest-api-account/src/main/java/org/oscm/rest/account/AccountBackend.java
+++ b/oscm-rest-api-account/src/main/java/org/oscm/rest/account/AccountBackend.java
@@ -33,7 +33,6 @@ public class AccountBackend {
 
   @EJB OperatorService os;
 
-  //TODO: Test
   public RestBackend.Post<BillingContactRepresentation, AccountParameters> postBillingContact() {
     return (content, params) -> {
       VOBillingContact vo = content.getVO();

--- a/oscm-rest-api-account/src/main/java/org/oscm/rest/account/AccountBackend.java
+++ b/oscm-rest-api-account/src/main/java/org/oscm/rest/account/AccountBackend.java
@@ -38,8 +38,9 @@ public class AccountBackend {
       VOBillingContact vo = content.getVO();
       VOBillingContact responseVO = as.saveBillingContact(vo);
       return PostResponseBody.of()
-          .createdObjectName(vo.getId())
-          .createdObjectId(String.valueOf(vo.getKey()));
+          .createdObjectName(responseVO.getId())
+          .createdObjectId(String.valueOf(responseVO.getKey()))
+          .build();
     };
   }
 
@@ -166,7 +167,10 @@ public class AccountBackend {
         // active
         return null;
       }
-      return org.getOrganizationId();
+      return PostResponseBody.of()
+          .createdObjectName(org.getOrganizationId())
+          .createdObjectId(String.valueOf(org.getKey()))
+          .build();
     };
   }
 

--- a/oscm-rest-api-account/src/test/java/org/oscm/rest/account/AccountBackendTest.java
+++ b/oscm-rest-api-account/src/test/java/org/oscm/rest/account/AccountBackendTest.java
@@ -25,6 +25,7 @@ import org.oscm.internal.intf.OperatorService;
 import org.oscm.internal.vo.VOBillingContact;
 import org.oscm.internal.vo.VOOperatorOrganization;
 import org.oscm.internal.vo.VOPaymentInfo;
+import org.oscm.rest.common.PostResponseBody;
 import org.oscm.rest.common.TestContants;
 import org.oscm.rest.common.representation.*;
 import org.oscm.rest.common.SampleTestDataUtility;
@@ -249,6 +250,9 @@ public class AccountBackendTest {
     assertThat(response)
         .extracting(Response::getStatus)
         .isEqualTo(Response.Status.CREATED.getStatusCode());
+    assertThat(response).extracting(Response::hasEntity).isEqualTo(true);
+    assertThat((PostResponseBody) response.getEntity()).extracting(PostResponseBody::getCreatedObjectId).isNotNull();
+    assertThat((PostResponseBody) response.getEntity()).extracting(PostResponseBody::getCreatedObjectName).isNotNull();
   }
 
   private static Stream<Arguments> provideRepresentationForCreatingOrganization() {

--- a/oscm-rest-api-account/src/test/java/org/oscm/rest/account/BillingContactResourceTest.java
+++ b/oscm-rest-api-account/src/test/java/org/oscm/rest/account/BillingContactResourceTest.java
@@ -18,6 +18,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.oscm.internal.vo.VOBillingContact;
+import org.oscm.rest.common.PostResponseBody;
 import org.oscm.rest.common.representation.BillingContactRepresentation;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.SampleTestDataUtility;
@@ -83,8 +85,10 @@ public class BillingContactResourceTest {
 
   @Test
   public void shouldCreateBillingContact() {
+    VOBillingContact vo = SampleTestDataUtility.createBillingContactVO();
     when(accountBackend.postBillingContact())
-        .thenReturn(((billingContactRepresentation, accountParameters) -> "newId"));
+        .thenReturn(((billingContactRepresentation, accountParameters) -> PostResponseBody.of().createdObjectId(
+                String.valueOf(vo.getKey())).createdObjectName(vo.getId()).build()));
 
     try {
       result = resource.createBillingContact(uriInfo, representation, parameters);
@@ -96,6 +100,9 @@ public class BillingContactResourceTest {
     assertThat(result)
         .extracting(Response::getStatus)
         .isEqualTo(Response.Status.CREATED.getStatusCode());
+    assertThat(result).extracting(Response::hasEntity).isEqualTo(true);
+    assertThat((PostResponseBody) result.getEntity()).extracting(PostResponseBody::getCreatedObjectId).isNotNull();
+    assertThat((PostResponseBody) result.getEntity()).extracting(PostResponseBody::getCreatedObjectName).isNotNull();
   }
 
   @Test

--- a/oscm-rest-api-account/src/test/java/org/oscm/rest/account/OrganizationResourceTest.java
+++ b/oscm-rest-api-account/src/test/java/org/oscm/rest/account/OrganizationResourceTest.java
@@ -17,15 +17,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.oscm.internal.vo.VOOrganization;
+import org.oscm.rest.common.PostResponseBody;
+import org.oscm.rest.common.SampleTestDataUtility;
 import org.oscm.rest.common.representation.AccountRepresentation;
 import org.oscm.rest.common.representation.OrganizationRepresentation;
-import org.oscm.rest.common.representation.UserRepresentation;
-import org.oscm.rest.common.SampleTestDataUtility;
 import org.oscm.rest.common.requestparameters.AccountParameters;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,8 +59,14 @@ public class OrganizationResourceTest {
 
   @Test
   public void shouldCreateOrganization() {
+    VOOrganization vo = SampleTestDataUtility.createVOOrganization();
     when(backend.postOrganization())
-        .thenReturn(((accountRepresentation, accountParameters) -> "newId"));
+        .thenReturn(
+            ((accountRepresentation, accountParameters) ->
+                PostResponseBody.of()
+                    .createdObjectName(vo.getOrganizationId())
+                    .createdObjectId(String.valueOf(vo.getKey()))
+                    .build()));
 
     try {
       result = resource.createOrganization(uriInfo, accountRepresentation, parameters);
@@ -72,6 +78,13 @@ public class OrganizationResourceTest {
     assertThat(result)
         .extracting(Response::getStatus)
         .isEqualTo(Response.Status.CREATED.getStatusCode());
+    assertThat(result).extracting(Response::hasEntity).isEqualTo(true);
+    assertThat((PostResponseBody) result.getEntity())
+        .extracting(PostResponseBody::getCreatedObjectId)
+        .isNotNull();
+    assertThat((PostResponseBody) result.getEntity())
+        .extracting(PostResponseBody::getCreatedObjectName)
+        .isNotNull();
   }
 
   @Test

--- a/oscm-rest-api-common/src/main/java/org/oscm/rest/common/PostResponseBody.java
+++ b/oscm-rest-api-common/src/main/java/org/oscm/rest/common/PostResponseBody.java
@@ -19,4 +19,5 @@ import lombok.Value;
 @Builder(builderMethodName = "of")
 public class PostResponseBody {
         private String createdObjectId;
+        private String createdObjectName;
 }

--- a/oscm-rest-api-common/src/main/java/org/oscm/rest/common/RestResource.java
+++ b/oscm-rest-api-common/src/main/java/org/oscm/rest/common/RestResource.java
@@ -9,21 +9,22 @@
  */
 package org.oscm.rest.common;
 
-import static org.oscm.rest.common.CommonParams.PARAM_VERSION;
-
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.security.SecuritySchemes;
-import java.util.List;
+import org.oscm.rest.common.representation.Representation;
+import org.oscm.rest.common.requestparameters.RequestParameters;
+
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-import org.oscm.rest.common.representation.Representation;
-import org.oscm.rest.common.requestparameters.RequestParameters;
+import java.util.List;
+
+import static org.oscm.rest.common.CommonParams.PARAM_VERSION;
 
 /**
  * Super class for REST resources and their endpoints.
@@ -120,11 +121,8 @@ public abstract class RestResource {
 
     prepareData(version, params, false, content, true);
 
-    Object newId = backend.post(content, params);
-
-    return Response.status(Response.Status.CREATED)
-        .entity(PostResponseBody.of().createdObjectId(newId.toString()).build())
-        .build();
+    Object response = backend.post(content, params);
+    return Response.status(Response.Status.CREATED).entity(response).build();
   }
 
   /**

--- a/oscm-rest-api-common/src/main/java/org/oscm/rest/common/SampleTestDataUtility.java
+++ b/oscm-rest-api-common/src/main/java/org/oscm/rest/common/SampleTestDataUtility.java
@@ -157,6 +157,7 @@ public class SampleTestDataUtility {
   public static VOBillingContact createBillingContactVO() {
     VOBillingContact vo = new VOBillingContact();
     vo.setKey(TestContants.LONG_VALUE);
+    vo.setId("con@tact.com");
     return vo;
   }
 
@@ -330,6 +331,8 @@ public class SampleTestDataUtility {
 
   public static VOOrganization createVOOrganization() {
     VOOrganization vo = new VOOrganization();
+    vo.setOrganizationId("orgid");
+    vo.setKey(123);
     return vo;
   }
 

--- a/oscm-rest-api-event/src/main/java/org/oscm/rest/event/EventBackend.java
+++ b/oscm-rest-api-event/src/main/java/org/oscm/rest/event/EventBackend.java
@@ -24,7 +24,6 @@ public class EventBackend {
   @EJB EventService es;
   private Response restResponse;
 
-  // FIXME: Explicit package name should be removed in scope of oscm#419
   public RestBackend.Post<EventRepresentation, EventParameters> post()
       throws DuplicateEventException, OrganizationAuthoritiesException, ObjectNotFoundException,
           ValidationException, java.lang.IllegalArgumentException, SaaSSystemException {

--- a/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/UserBackend.java
+++ b/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/UserBackend.java
@@ -9,20 +9,22 @@
  */
 package org.oscm.rest.identity;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import javax.ejb.EJB;
-import javax.ejb.Stateless;
 import org.oscm.internal.intf.IdentityService;
 import org.oscm.internal.vo.VOUser;
 import org.oscm.internal.vo.VOUserDetails;
+import org.oscm.rest.common.PostResponseBody;
 import org.oscm.rest.common.RestBackend;
 import org.oscm.rest.common.representation.OnBehalfUserRepresentation;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.representation.RolesRepresentation;
 import org.oscm.rest.common.representation.UserRepresentation;
 import org.oscm.rest.common.requestparameters.UserParameters;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 
 @Stateless
 public class UserBackend {
@@ -60,7 +62,10 @@ public class UserBackend {
       if (vo == null) {
         return null;
       }
-      return vo.getUserId();
+      return PostResponseBody.of()
+          .createdObjectId(String.valueOf(vo.getKey()))
+          .createdObjectName(vo.getUserId())
+          .build();
     };
   }
 
@@ -108,9 +113,16 @@ public class UserBackend {
     };
   }
 
+  //TODO: Test
   public RestBackend.Post<OnBehalfUserRepresentation, UserParameters> postOnBehalfUser() {
-    return (content, params) ->
-        is.createOnBehalfUser(content.getOrganizationId(), content.getPassword()).getUserId();
+    return (content, params) -> {
+      VOUserDetails userDetails =
+          is.createOnBehalfUser(content.getOrganizationId(), content.getPassword());
+      return PostResponseBody.of()
+          .createdObjectId(String.valueOf(userDetails.getKey()))
+          .createdObjectName(userDetails.getUserId())
+          .build();
+    };
   }
 
   public RestBackend.Delete<UserParameters> deleteOBehalfUser() {

--- a/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/UserBackend.java
+++ b/oscm-rest-api-identity/src/main/java/org/oscm/rest/identity/UserBackend.java
@@ -113,7 +113,6 @@ public class UserBackend {
     };
   }
 
-  //TODO: Test
   public RestBackend.Post<OnBehalfUserRepresentation, UserParameters> postOnBehalfUser() {
     return (content, params) -> {
       VOUserDetails userDetails =

--- a/oscm-rest-api-identity/src/test/java/org/oscm/rest/identity/UserResourceTest.java
+++ b/oscm-rest-api-identity/src/test/java/org/oscm/rest/identity/UserResourceTest.java
@@ -18,10 +18,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.oscm.rest.common.representation.RepresentationCollection;
+import org.oscm.rest.common.PostResponseBody;
 import org.oscm.rest.common.SampleTestDataUtility;
-import org.oscm.rest.common.requestparameters.UserParameters;
+import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.representation.UserRepresentation;
+import org.oscm.rest.common.requestparameters.UserParameters;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -82,7 +83,10 @@ public class UserResourceTest {
 
   @Test
   public void shouldCreateUser() {
-    when(userBackend.postUser()).thenReturn((userRepresentation1, userParameters) -> "newId");
+    when(userBackend.postUser())
+        .thenReturn(
+            (userRepresentation1, userParameters) ->
+                PostResponseBody.of().createdObjectId("id").createdObjectName("name").build());
 
     try {
       result = userResource.createUser(uriInfo, userRepresentation, parameters);
@@ -94,6 +98,13 @@ public class UserResourceTest {
     assertThat(result)
         .extracting(Response::getStatus)
         .isEqualTo(Response.Status.CREATED.getStatusCode());
+    assertThat(result).extracting(Response::hasEntity).isEqualTo(true);
+    assertThat((PostResponseBody) result.getEntity())
+        .extracting(PostResponseBody::getCreatedObjectId)
+        .isNotNull();
+    assertThat((PostResponseBody) result.getEntity())
+        .extracting(PostResponseBody::getCreatedObjectName)
+        .isNotNull();
   }
 
   @Test

--- a/oscm-rest-api-marketplace/src/main/java/org/oscm/rest/marketplace/MarketplaceBackend.java
+++ b/oscm-rest-api-marketplace/src/main/java/org/oscm/rest/marketplace/MarketplaceBackend.java
@@ -53,7 +53,6 @@ public class MarketplaceBackend {
     };
   }
 
-  // TODO: Test
   public RestBackend.Post<MarketplaceRepresentation, MarketplaceParameters> post() {
     return (content, params) -> {
       VOMarketplace mp = ms.createMarketplace(content.getVO());

--- a/oscm-rest-api-marketplace/src/main/java/org/oscm/rest/marketplace/MarketplaceBackend.java
+++ b/oscm-rest-api-marketplace/src/main/java/org/oscm/rest/marketplace/MarketplaceBackend.java
@@ -9,18 +9,20 @@
  */
 package org.oscm.rest.marketplace;
 
-import java.util.List;
-import javax.ejb.ConcurrentAccessException;
-import javax.ejb.EJB;
-import javax.ejb.Stateless;
 import org.oscm.internal.intf.MarketplaceService;
-import org.oscm.internal.types.exception.*;
 import org.oscm.internal.types.exception.IllegalArgumentException;
+import org.oscm.internal.types.exception.*;
 import org.oscm.internal.vo.VOMarketplace;
+import org.oscm.rest.common.PostResponseBody;
 import org.oscm.rest.common.RestBackend;
 import org.oscm.rest.common.representation.MarketplaceRepresentation;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.requestparameters.MarketplaceParameters;
+
+import javax.ejb.ConcurrentAccessException;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import java.util.List;
 
 @Stateless
 public class MarketplaceBackend {
@@ -51,10 +53,14 @@ public class MarketplaceBackend {
     };
   }
 
+  // TODO: Test
   public RestBackend.Post<MarketplaceRepresentation, MarketplaceParameters> post() {
     return (content, params) -> {
       VOMarketplace mp = ms.createMarketplace(content.getVO());
-      return Long.valueOf(mp.getKey());
+      return PostResponseBody.of()
+          .createdObjectName(mp.getName())
+          .createdObjectId(String.valueOf(mp.getKey()))
+          .build();
     };
   }
 

--- a/oscm-rest-api-operation/src/main/java/org/oscm/rest/operation/SettingsBackend.java
+++ b/oscm-rest-api-operation/src/main/java/org/oscm/rest/operation/SettingsBackend.java
@@ -12,9 +12,10 @@ package org.oscm.rest.operation;
 import org.oscm.internal.intf.ConfigurationService;
 import org.oscm.internal.intf.OperatorService;
 import org.oscm.internal.vo.VOConfigurationSetting;
+import org.oscm.rest.common.PostResponseBody;
 import org.oscm.rest.common.RestBackend;
-import org.oscm.rest.common.requestparameters.OperationParameters;
 import org.oscm.rest.common.representation.SettingRepresentation;
+import org.oscm.rest.common.requestparameters.OperationParameters;
 
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
@@ -34,12 +35,16 @@ public class SettingsBackend {
     };
   }
 
+  // TODO: Test
   public RestBackend.Post<SettingRepresentation, OperationParameters> post() throws Exception {
     return (content, params) -> {
       os.saveConfigurationSetting(content.getVO());
       VOConfigurationSetting vo =
           cs.getVOConfigurationSetting(content.getInformationId(), content.getContextId());
-      return Long.valueOf(vo.getKey());
+      return PostResponseBody.of()
+          .createdObjectId(String.valueOf(vo.getKey()))
+          .createdObjectName(vo.getContextId())
+          .build();
     };
   }
 

--- a/oscm-rest-api-operation/src/main/java/org/oscm/rest/operation/SettingsBackend.java
+++ b/oscm-rest-api-operation/src/main/java/org/oscm/rest/operation/SettingsBackend.java
@@ -35,7 +35,6 @@ public class SettingsBackend {
     };
   }
 
-  // TODO: Test
   public RestBackend.Post<SettingRepresentation, OperationParameters> post() throws Exception {
     return (content, params) -> {
       os.saveConfigurationSetting(content.getVO());

--- a/oscm-rest-api-operation/src/main/java/org/oscm/rest/operation/SettingsBackend.java
+++ b/oscm-rest-api-operation/src/main/java/org/oscm/rest/operation/SettingsBackend.java
@@ -42,7 +42,6 @@ public class SettingsBackend {
           cs.getVOConfigurationSetting(content.getInformationId(), content.getContextId());
       return PostResponseBody.of()
           .createdObjectId(String.valueOf(vo.getKey()))
-          .createdObjectName(vo.getContextId())
           .build();
     };
   }

--- a/oscm-rest-api-operation/src/test/java/org/oscm/rest/operation/SettingsBackendTest.java
+++ b/oscm-rest-api-operation/src/test/java/org/oscm/rest/operation/SettingsBackendTest.java
@@ -20,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.oscm.internal.intf.ConfigurationService;
 import org.oscm.internal.intf.OperatorService;
 import org.oscm.internal.vo.VOConfigurationSetting;
+import org.oscm.rest.common.PostResponseBody;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.SampleTestDataUtility;
 import org.oscm.rest.common.requestparameters.OperationParameters;
@@ -103,6 +104,8 @@ public class SettingsBackendTest {
     assertThat(response)
         .extracting(Response::getStatus)
         .isEqualTo(Response.Status.CREATED.getStatusCode());
+    assertThat(response).extracting(Response::hasEntity).isEqualTo(true);
+    assertThat((PostResponseBody) response.getEntity()).extracting(PostResponseBody::getCreatedObjectId).isNotNull();
   }
 
   @Test

--- a/oscm-rest-api-operation/src/test/java/org/oscm/rest/operation/SettingsResourceTest.java
+++ b/oscm-rest-api-operation/src/test/java/org/oscm/rest/operation/SettingsResourceTest.java
@@ -18,10 +18,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.oscm.rest.common.representation.RepresentationCollection;
+import org.oscm.rest.common.PostResponseBody;
 import org.oscm.rest.common.SampleTestDataUtility;
-import org.oscm.rest.common.requestparameters.OperationParameters;
+import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.representation.SettingRepresentation;
+import org.oscm.rest.common.requestparameters.OperationParameters;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -86,7 +87,9 @@ class SettingsResourceTest {
   public void shouldCreateSettings() {
     try {
       when(settingsBackend.post())
-          .thenReturn((settingRepresentation1, operationParameters) -> 100L);
+          .thenReturn(
+              (settingRepresentation1, operationParameters) ->
+                  PostResponseBody.of().createdObjectId(String.valueOf(123)).build());
     } catch (Exception e) {
       fail(e);
     }
@@ -103,6 +106,9 @@ class SettingsResourceTest {
         .extracting(Response::getStatus)
         .isEqualTo(Response.Status.CREATED.getStatusCode());
     assertThat(response).extracting(Response::hasEntity).isEqualTo(true);
+    assertThat((PostResponseBody) response.getEntity())
+        .extracting(PostResponseBody::getCreatedObjectId)
+        .isNotNull();
   }
 
   @Test

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/ServiceBackend.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/ServiceBackend.java
@@ -14,12 +14,13 @@ import org.oscm.internal.types.exception.DomainObjectException.ClassEnum;
 import org.oscm.internal.types.exception.ObjectNotFoundException;
 import org.oscm.internal.vo.VOService;
 import org.oscm.internal.vo.VOServiceDetails;
-import org.oscm.rest.common.representation.RepresentationCollection;
+import org.oscm.rest.common.PostResponseBody;
 import org.oscm.rest.common.RestBackend;
-import org.oscm.rest.common.requestparameters.ServiceParameters;
+import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.representation.ServiceDetailsRepresentation;
 import org.oscm.rest.common.representation.ServiceRepresentation;
 import org.oscm.rest.common.representation.StatusRepresentation;
+import org.oscm.rest.common.requestparameters.ServiceParameters;
 
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
@@ -42,7 +43,10 @@ public class ServiceBackend {
       // image will be handled in separate URL
       VOServiceDetails vo =
           sps.createService(content.getTechnicalService().getVO(), content.getVO(), null);
-      return Long.valueOf(vo.getKey());
+      return PostResponseBody.of()
+          .createdObjectId(String.valueOf(vo.getKey()))
+          .createdObjectName(vo.getServiceId())
+          .build();
     };
   }
 

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TSSupplierBackend.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TSSupplierBackend.java
@@ -36,7 +36,6 @@ public class TSSupplierBackend {
     };
   }
 
-  //TODO: Test
   public RestBackend.Post<OrganizationRepresentation, ServiceParameters> post() {
     return (content, params) -> {
       VOTechnicalService vo = new VOTechnicalService();

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TSSupplierBackend.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TSSupplierBackend.java
@@ -9,16 +9,18 @@
  */
 package org.oscm.rest.service;
 
-import java.util.Arrays;
-import java.util.List;
-import javax.ejb.EJB;
-import javax.ejb.Stateless;
 import org.oscm.internal.intf.AccountService;
 import org.oscm.internal.vo.VOOrganization;
 import org.oscm.internal.vo.VOTechnicalService;
+import org.oscm.rest.common.PostResponseBody;
 import org.oscm.rest.common.RestBackend;
 import org.oscm.rest.common.representation.OrganizationRepresentation;
 import org.oscm.rest.common.requestparameters.ServiceParameters;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import java.util.Arrays;
+import java.util.List;
 
 @Stateless
 public class TSSupplierBackend {
@@ -34,12 +36,16 @@ public class TSSupplierBackend {
     };
   }
 
+  //TODO: Test
   public RestBackend.Post<OrganizationRepresentation, ServiceParameters> post() {
     return (content, params) -> {
       VOTechnicalService vo = new VOTechnicalService();
       vo.setKey(params.getId().longValue());
       as.addSuppliersForTechnicalService(vo, Arrays.asList(content.getOrganizationId()));
-      return content.getOrganizationId();
+      return PostResponseBody.of()
+          .createdObjectName(content.getOrganizationId())
+          .createdObjectId(String.valueOf(vo.getKey()))
+          .build();
     };
   }
 

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TechnicalServiceBackend.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TechnicalServiceBackend.java
@@ -47,7 +47,6 @@ public class TechnicalServiceBackend {
     };
   }
 
-  // TODO: Test
   public RestBackend.Post<TechnicalServiceRepresentation, ServiceParameters> post() {
     return (content, params) -> {
       VOTechnicalService ts = sps.createTechnicalService(content.getVO());

--- a/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TechnicalServiceBackend.java
+++ b/oscm-rest-api-service/src/main/java/org/oscm/rest/service/TechnicalServiceBackend.java
@@ -12,10 +12,11 @@ package org.oscm.rest.service;
 import org.oscm.internal.intf.ServiceProvisioningService;
 import org.oscm.internal.types.enumtypes.OrganizationRoleType;
 import org.oscm.internal.vo.VOTechnicalService;
-import org.oscm.rest.common.representation.RepresentationCollection;
+import org.oscm.rest.common.PostResponseBody;
 import org.oscm.rest.common.RestBackend;
-import org.oscm.rest.common.requestparameters.ServiceParameters;
+import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.representation.TechnicalServiceRepresentation;
+import org.oscm.rest.common.requestparameters.ServiceParameters;
 
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
@@ -46,10 +47,14 @@ public class TechnicalServiceBackend {
     };
   }
 
+  // TODO: Test
   public RestBackend.Post<TechnicalServiceRepresentation, ServiceParameters> post() {
     return (content, params) -> {
       VOTechnicalService ts = sps.createTechnicalService(content.getVO());
-      return Long.valueOf(ts.getKey());
+      return PostResponseBody.of()
+          .createdObjectId(String.valueOf(ts.getKey()))
+          .createdObjectName(ts.getTechnicalServiceId())
+          .build();
     };
   }
 }

--- a/oscm-rest-api-subscription/src/main/java/org/oscm/rest/subscription/SubscriptionBackend.java
+++ b/oscm-rest-api-subscription/src/main/java/org/oscm/rest/subscription/SubscriptionBackend.java
@@ -72,7 +72,6 @@ public class SubscriptionBackend {
     };
   }
 
-  //TODO: Test
   public RestBackend.Post<SubscriptionCreationRepresentation, SubscriptionParameters> post() {
     return (content, params) -> {
       content.getService().update();

--- a/oscm-rest-api-subscription/src/main/java/org/oscm/rest/subscription/SubscriptionBackend.java
+++ b/oscm-rest-api-subscription/src/main/java/org/oscm/rest/subscription/SubscriptionBackend.java
@@ -10,20 +10,22 @@
 package org.oscm.rest.subscription;
 
 import com.google.common.collect.Lists;
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
-import javax.ejb.EJB;
-import javax.ejb.Stateless;
 import org.oscm.internal.intf.SubscriptionService;
 import org.oscm.internal.intf.SubscriptionServiceInternal;
 import org.oscm.internal.types.enumtypes.PerformanceHint;
 import org.oscm.internal.vo.VOSubscription;
 import org.oscm.internal.vo.VOSubscriptionDetails;
 import org.oscm.internal.vo.VOUser;
+import org.oscm.rest.common.PostResponseBody;
 import org.oscm.rest.common.RestBackend;
 import org.oscm.rest.common.representation.*;
 import org.oscm.rest.common.requestparameters.SubscriptionParameters;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Stateless
 public class SubscriptionBackend {
@@ -70,6 +72,7 @@ public class SubscriptionBackend {
     };
   }
 
+  //TODO: Test
   public RestBackend.Post<SubscriptionCreationRepresentation, SubscriptionParameters> post() {
     return (content, params) -> {
       content.getService().update();
@@ -86,7 +89,11 @@ public class SubscriptionBackend {
       if (sub == null) {
         return null;
       }
-      return Long.valueOf(sub.getKey());
+
+      return PostResponseBody.of()
+          .createdObjectId(String.valueOf(sub.getKey()))
+          .createdObjectName(sub.getSubscriptionId())
+          .build();
     };
   }
 

--- a/oscm-rest-api-subscription/src/main/java/org/oscm/rest/subscription/UsageLicenseBackend.java
+++ b/oscm-rest-api-subscription/src/main/java/org/oscm/rest/subscription/UsageLicenseBackend.java
@@ -9,17 +9,19 @@
  */
 package org.oscm.rest.subscription;
 
-import java.util.Collections;
-import java.util.List;
-import javax.ejb.EJB;
-import javax.ejb.Stateless;
 import org.oscm.internal.intf.SubscriptionService;
 import org.oscm.internal.vo.VOSubscriptionDetails;
 import org.oscm.internal.vo.VOUsageLicense;
+import org.oscm.rest.common.PostResponseBody;
 import org.oscm.rest.common.RestBackend;
 import org.oscm.rest.common.representation.RepresentationCollection;
 import org.oscm.rest.common.representation.UsageLicenseRepresentation;
 import org.oscm.rest.common.requestparameters.SubscriptionParameters;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import java.util.Collections;
+import java.util.List;
 
 @Stateless
 public class UsageLicenseBackend {
@@ -45,7 +47,7 @@ public class UsageLicenseBackend {
           }
         }
       }
-      return licKey;
+      return PostResponseBody.of().createdObjectId(String.valueOf(licKey)).build();
     };
   }
 


### PR DESCRIPTION
**Changes in this Pull Request:**
- Post endpoints now returns both key and id

**Mandatory checks:**
- [x] latest changes were fetched from the upstream branch before creating this PR (branch is up to date)
- [x] changes were tested manually
- [x] unit tests were properly implemented
- [x] communication about interdependent changes has been sent to the team (if applicable)
- [x] respective Jenkins jobs were referenced in *additional context* section of this PR

**OSCM Build References:**
N/A

Closes #163 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm-rest-api/173)
<!-- Reviewable:end -->
