### PR TITLE
Fixed broken google-java-format URL

### DIFF
--- a/scripts/format_code.sh
+++ b/scripts/format_code.sh
@@ -8,7 +8,7 @@ determine_files_to_process
 
 if [[ ! -z "$GIT_DIFF_OUTPUT" ]] ; then
     if [ ! -f libraries/google-java-format.jar ] ; then 
-        curl -o libraries/google-java-format.jar http://central.maven.org/maven2/com/google/googlejavaformat/google-java-format/1.7/google-java-format-1.7-all-deps.jar
+        curl -o libraries/google-java-format.jar https://repo1.maven.org/maven2/com/google/googlejavaformat/google-java-format/1.7/google-java-format-1.7-all-deps.jar
         chmod 755 libraries/google-java-format.jar
     fi
 


### PR DESCRIPTION
This PR is fixing an issue with broken maven repository URL.
It's virtually the same issue as in case of broken IVY urls.
This fix is of course also included in code fromatter on main oscm-repository

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm-rest-api/181)
<!-- Reviewable:end -->
